### PR TITLE
지출 추가 기능 구현

### DIFF
--- a/src/common/components/Chip/index.tsx
+++ b/src/common/components/Chip/index.tsx
@@ -14,7 +14,7 @@ function Chip({ label, closable, onClose, variant = 'gray' }: ChipProps) {
       <S.ChipLabel>{label}</S.ChipLabel>
       {closable && (
         <S.CloseButton onClick={onClose}>
-          <Close />
+          <Close width="1.5rem" fill="#444950" />
         </S.CloseButton>
       )}
     </S.Chip>

--- a/src/pages/createBill/addExpenseStep/components/FormCard/index.styles.ts
+++ b/src/pages/createBill/addExpenseStep/components/FormCard/index.styles.ts
@@ -9,8 +9,17 @@ export const FormCard = styled(Card.Root)`
   gap: 1.5rem;
 `;
 
-export const FormCardTitle = styled(Card.Title)`
+export const FormCardTitleContainer = styled(Card.Title)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+`;
+
+export const FormCardTitle = styled.span`
   font-size: 1.25rem;
   font-weight: 700; // bold
   color: #000000;
 `;
+
+export const FormDeleteButton = styled.button``;

--- a/src/pages/createBill/addExpenseStep/components/FormCard/index.tsx
+++ b/src/pages/createBill/addExpenseStep/components/FormCard/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { Close } from '@/assets/svgs/icon';
 import distributeAmount from '@/pages/createBill/utils/distributeExpense';
 import { ExpenseMember } from '@/pages/createBill/types/expense.type';
 import BillDatePicker from '../DatePicker';
@@ -11,9 +12,10 @@ import * as S from './index.styles';
 
 interface FormCardProps {
   index: number;
+  onDelete: (index: number) => void; // 폼 삭제 버튼 클릭 시 호출되는 함수
 }
 
-function FormCard({ index }: FormCardProps) {
+function FormCard({ index, onDelete }: FormCardProps) {
   const { register, watch, setValue, control } = useFormContext();
   const [openNumPad, setOpenNumPad] = useState(false);
 
@@ -46,7 +48,14 @@ function FormCard({ index }: FormCardProps) {
 
   return (
     <S.FormCard>
-      <S.FormCardTitle>1차</S.FormCardTitle>
+      <S.FormCardTitleContainer>
+        <S.FormCardTitle>{index + 1}차</S.FormCardTitle>
+        {index > 0 ? (
+          <S.FormDeleteButton type="button" onClick={() => onDelete(index)}>
+            <Close width="1.5rem" />
+          </S.FormDeleteButton>
+        ) : null}
+      </S.FormCardTitleContainer>
       <FormField
         label="결제 금액"
         required

--- a/src/pages/createBill/addExpenseStep/components/FormCard/index.tsx
+++ b/src/pages/createBill/addExpenseStep/components/FormCard/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { Close } from '@/assets/svgs/icon';
 import distributeAmount from '@/pages/createBill/utils/distributeExpense';
@@ -15,101 +15,106 @@ interface FormCardProps {
   onDelete: (index: number) => void; // 폼 삭제 버튼 클릭 시 호출되는 함수
 }
 
-function FormCard({ index, onDelete }: FormCardProps) {
-  const { register, watch, setValue, control } = useFormContext();
-  const [openNumPad, setOpenNumPad] = useState(false);
+const FormCard = forwardRef<HTMLDivElement, FormCardProps>(
+  ({ index, onDelete }, ref) => {
+    const { register, watch, setValue, control } = useFormContext();
+    const [openNumPad, setOpenNumPad] = useState(false);
 
-  const amount = watch(`expenses.${index}.amount`);
-  const memberExpenses = watch(`expenses.${index}.memberExpenses`);
+    const amount = watch(`expenses.${index}.amount`);
+    const memberExpenses = watch(`expenses.${index}.memberExpenses`);
 
-  useEffect(() => {
-    if (!amount || !memberExpenses) return;
-    if (amount && memberExpenses && memberExpenses.length > 0) {
-      // 지출 금액을 참여자 수에 맞게 분배
-      const distribution = distributeAmount(amount, memberExpenses.length);
-      const updatedMemberExpenses = memberExpenses.map(
-        (member: ExpenseMember, idx: number) => ({
-          ...member,
-          amount: distribution[idx],
-        })
-      );
+    useEffect(() => {
+      if (!amount || !memberExpenses) return;
+      if (amount && memberExpenses && memberExpenses.length > 0) {
+        // 지출 금액을 참여자 수에 맞게 분배
+        const distribution = distributeAmount(amount, memberExpenses.length);
+        const updatedMemberExpenses = memberExpenses.map(
+          (member: ExpenseMember, idx: number) => ({
+            ...member,
+            amount: distribution[idx],
+          })
+        );
 
-      // 참여자별 지출 금액이 변경된 경우에만 업데이트
-      if (
-        JSON.stringify(updatedMemberExpenses) !== JSON.stringify(memberExpenses)
-      ) {
-        setValue(`expenses.${index}.memberExpenses`, updatedMemberExpenses, {
-          shouldValidate: true,
-          shouldDirty: true,
-        });
+        // 참여자별 지출 금액이 변경된 경우에만 업데이트
+        if (
+          JSON.stringify(updatedMemberExpenses) !==
+          JSON.stringify(memberExpenses)
+        ) {
+          setValue(`expenses.${index}.memberExpenses`, updatedMemberExpenses, {
+            shouldValidate: true,
+            shouldDirty: true,
+          });
+        }
       }
-    }
-  }, [amount, index, memberExpenses, setValue]);
+    }, [amount, index, memberExpenses, setValue]);
 
-  return (
-    <S.FormCard>
-      <S.FormCardTitleContainer>
-        <S.FormCardTitle>{index + 1}차</S.FormCardTitle>
-        {index > 0 ? (
-          <S.FormDeleteButton type="button" onClick={() => onDelete(index)}>
-            <Close width="1.5rem" />
-          </S.FormDeleteButton>
-        ) : null}
-      </S.FormCardTitleContainer>
-      <FormField
-        label="결제 금액"
-        required
-        control={control}
-        name={`expenses.${index}.amount`}
-        renderInput={({ field }) => (
-          <NumPadBottomSheet
-            initialInput={field.value}
-            open={openNumPad}
-            setOpen={setOpenNumPad}
-            setInput={(value) => field.onChange(value)}
-          />
-        )}
-      />
-      <FormField
-        label="지출 장소 및 내용"
-        required
-        register={register(`expenses.${index}.content`)}
-        name={`expenses.${index}.content`}
-        placeholder="ex. 투썸플레이스"
-      />
-      <FormField
-        label="지출일"
-        control={control}
-        name={`expenses.${index}.date`}
-        renderInput={({ field }) => (
-          <BillDatePicker
-            selected={field.value}
-            onChange={(date) => field.onChange(date)}
-          />
-        )}
-      />
-      <FormField
-        label="참여자"
-        name={`expenses.${index}.memberExpenses`}
-        control={control}
-        subButton={{
-          label: '참여자 추가',
-          onClick: () => console.log('참여자 추가 바텀시트 등장'),
-        }}
-        renderInput={({ field }) => (
-          <MemberChips
-            members={field.value}
-            onDelete={(name) => {
-              const newMembers = field.value.filter(
-                (member: ExpenseMember) => member.name !== name
-              );
-              field.onChange(newMembers);
-            }}
-          />
-        )}
-      />
-    </S.FormCard>
-  );
-}
+    return (
+      <S.FormCard ref={ref}>
+        <S.FormCardTitleContainer>
+          <S.FormCardTitle>{index + 1}차</S.FormCardTitle>
+          {index > 0 ? (
+            <S.FormDeleteButton type="button" onClick={() => onDelete(index)}>
+              <Close width="1.5rem" />
+            </S.FormDeleteButton>
+          ) : null}
+        </S.FormCardTitleContainer>
+        <FormField
+          label="결제 금액"
+          required
+          control={control}
+          name={`expenses.${index}.amount`}
+          renderInput={({ field }) => (
+            <NumPadBottomSheet
+              initialInput={field.value}
+              open={openNumPad}
+              setOpen={setOpenNumPad}
+              setInput={(value) => field.onChange(value)}
+            />
+          )}
+        />
+        <FormField
+          label="지출 장소 및 내용"
+          required
+          register={register(`expenses.${index}.content`)}
+          name={`expenses.${index}.content`}
+          placeholder="ex. 투썸플레이스"
+        />
+        <FormField
+          label="지출일"
+          control={control}
+          name={`expenses.${index}.date`}
+          renderInput={({ field }) => (
+            <BillDatePicker
+              selected={field.value}
+              onChange={(date) => field.onChange(date)}
+            />
+          )}
+        />
+        <FormField
+          label="참여자"
+          name={`expenses.${index}.memberExpenses`}
+          control={control}
+          subButton={{
+            label: '참여자 추가',
+            onClick: () => console.log('참여자 추가 바텀시트 등장'),
+          }}
+          renderInput={({ field }) => (
+            <MemberChips
+              members={field.value}
+              onDelete={(name) => {
+                const newMembers = field.value.filter(
+                  (member: ExpenseMember) => member.name !== name
+                );
+                field.onChange(newMembers);
+              }}
+            />
+          )}
+        />
+      </S.FormCard>
+    );
+  }
+);
+
+FormCard.displayName = 'FormCard';
 
 export default FormCard;

--- a/src/pages/createBill/addExpenseStep/index.styles.ts
+++ b/src/pages/createBill/addExpenseStep/index.styles.ts
@@ -47,8 +47,10 @@ export const TabButton = styled.button<{ $isSelected: boolean }>`
 export const BillFormList = styled.form`
   display: flex;
   flex-direction: column;
+  gap: 1.5rem;
   width: 100%;
   flex: 1 0 0;
+  overflow-y: auto;
   padding: 1rem 1.25rem;
   background: #faf6f3;
 `;

--- a/src/pages/createBill/addExpenseStep/index.tsx
+++ b/src/pages/createBill/addExpenseStep/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Close } from '@/assets/svgs/icon';
@@ -31,6 +31,7 @@ interface AddExpenseStepProps
   extends BaseFunnelStepComponentProps<BillContext> {}
 
 function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
+  const lastFormCardRef = useRef<HTMLDivElement | null>(null);
   const [tabMode, setTabMode] = useState<'DIVIDE_N' | 'DIVIDE_CUSTOM'>(
     'DIVIDE_N'
   );
@@ -46,12 +47,21 @@ function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
     name: 'expenses',
   });
 
+  useLayoutEffect(() => {
+    // form의 개수가 변경되면 (추가, 삭제) 마지막 form으로 스크롤 이동
+    lastFormCardRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  }, [fields.length]);
+
   const { handleSubmit, formState, watch } = formMethods;
   const allFormsValid = formState.isValid;
   const expenses = watch('expenses');
 
   const handleAddExpense = () => {
-    append(defaultValues);
+    // 기본 focus 기능을 사용하지 않고 새로운 폼 추가
+    append(defaultValues, { shouldFocus: false });
   };
 
   const handleDeleteExpense = (index: number) => {
@@ -97,6 +107,7 @@ function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
         {fields.map((field, index) => (
           <BillFormCard
             key={field.id}
+            ref={index === fields.length - 1 ? lastFormCardRef : null}
             index={index}
             onDelete={handleDeleteExpense}
           />

--- a/src/pages/createBill/addExpenseStep/index.tsx
+++ b/src/pages/createBill/addExpenseStep/index.tsx
@@ -41,7 +41,7 @@ function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
       expenses: [defaultValues],
     },
   });
-  const { fields } = useFieldArray({
+  const { fields, append, remove } = useFieldArray({
     control: formMethods.control,
     name: 'expenses',
   });
@@ -49,6 +49,14 @@ function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
   const { handleSubmit, formState, watch } = formMethods;
   const allFormsValid = formState.isValid;
   const expenses = watch('expenses');
+
+  const handleAddExpense = () => {
+    append(defaultValues);
+  };
+
+  const handleDeleteExpense = (index: number) => {
+    remove(index);
+  };
 
   // 임시...
   const onFormSubmit = (data: any) => {
@@ -62,6 +70,7 @@ function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
         type="TitleCenter"
         leftButtonContent={<Close width="1.5rem" />}
         rightButtonContent={<S.AddExpenseButton>지출 추가</S.AddExpenseButton>}
+        rightButtonOnClick={handleAddExpense}
       />
       <S.TopWrapper>
         <S.TopMessage>
@@ -86,7 +95,11 @@ function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
       </S.TabContainer>
       <S.BillFormList>
         {fields.map((field, index) => (
-          <BillFormCard key={field.id} index={index} />
+          <BillFormCard
+            key={field.id}
+            index={index}
+            onDelete={handleDeleteExpense}
+          />
         ))}
       </S.BillFormList>
       {/* TODO : 지출 내역 입력_직접 입력하기 */}


### PR DESCRIPTION
## 📝 관련 이슈

- close #22 

## 💻 작업 내용

### 1. 디자인 수정

- 폼 목록에 스크롤을 추가했습니다.
- Safari에서는 Chip에서 사용하는 Close 아이콘의 색이 보이지 않는 문제가 있어 `fill` 속성으로 추가해줬습니다.

### 2. 지출 추가 / 삭제 기능 구현

#### 2-1. 지출 form 추가

useFieldArray의 append와 remove를 이용해서 폼 추가, 삭제 기능을 추가했습니다. 
참고: https://velog.io/@isolatorv/useFieldArray-사용하기

#### 2-2. 스크롤 이동

폼이 추가되고 삭제될 때 목록의 마지막 폼으로 스크롤이 부드럽게 이동되도록 했습니다.

- 스크롤을 이동하기 위한 ref를 FormCard에 전달할 수 있도록 FormCard를 forwardRef로 변경했습니다.
- 스크롤을 이동하는 로직을 추가했습니다. (useLayoutEffect 참고: https://www.howdy-mj.me/react/useEffect-and-useLayoutEffect)

## 📸 스크린샷

### 폼 추가, 삭제

https://github.com/user-attachments/assets/c401101b-4cdb-4e18-9436-6777f765a7b2

### 제출된 폼 결과

<img width="472" alt="Screen_Shot 2025-02-10 17 42 17" src="https://github.com/user-attachments/assets/5f3ecc22-00a1-4b5d-aa0d-c6ee9966e712" />
