### PR TITLE
공통 컴포넌트 Modal 구현

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -4,3 +4,4 @@
     overflow: auto;
   }
 </style>
+<div id="modal"></div>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/common/components/Modal/index.stories.tsx
+++ b/src/common/components/Modal/index.stories.tsx
@@ -79,7 +79,9 @@ const EmptyStory = (args: ModalProps) => {
   return (
     <>
       <Button onClick={() => setOpen(!open)}>Toggle Empty Modal</Button>
-      <Modal {...args} open={open} setOpen={setOpen} />
+      <Modal {...args} open={open} setOpen={setOpen}>
+        비어 있는 Modal입니다!
+      </Modal>
     </>
   );
 };

--- a/src/common/components/Modal/index.stories.tsx
+++ b/src/common/components/Modal/index.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Meta, StoryObj } from '@storybook/react';
-import Modal from '.';
+import Modal, { ModalProps } from '.';
 import Button from '../Button'; // Button 컴포넌트
 
 const SAMPLE_TITLE = '타이틀입력 최대 한줄';
@@ -39,6 +39,29 @@ export default meta;
 
 type Story = StoryObj<typeof Modal>;
 
+const DefaultStory = (args: ModalProps) => {
+  const [open, setOpen] = useState<boolean>(false);
+  const handleClick = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <>
+      <Button onClick={handleClick}>Toggle Default Modal</Button>
+      <Modal
+        {...args}
+        open={open}
+        setOpen={setOpen}
+        onCancel={handleClick}
+        onSubmit={() => {
+          alert('승인 버튼 클릭');
+          handleClick();
+        }}
+      />
+    </>
+  );
+};
+
 export const Default: Story = {
   args: {
     variant: 'default',
@@ -48,24 +71,17 @@ export const Default: Story = {
     submit: SAMPLE_SUBMIT,
   },
 
-  render: (args) => {
-    const [open, setOpen] = useState(false);
-    return (
-      <>
-        <Button onClick={() => setOpen(!open)}>Toggle Default Modal</Button>
-        <Modal
-          {...args}
-          open={open}
-          setOpen={setOpen}
-          onCancel={() => setOpen(false)}
-          onSubmit={() => {
-            alert('승인 버튼 클릭');
-            setOpen(false);
-          }}
-        />
-      </>
-    );
-  },
+  render: DefaultStory,
+};
+
+const EmptyStory = (args: ModalProps) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(!open)}>Toggle Empty Modal</Button>
+      <Modal {...args} open={open} setOpen={setOpen} />
+    </>
+  );
 };
 
 export const Empty: Story = {
@@ -73,13 +89,5 @@ export const Empty: Story = {
     variant: 'empty',
   },
 
-  render: (args) => {
-    const [open, setOpen] = useState(false);
-    return (
-      <>
-        <Button onClick={() => setOpen(!open)}>Toggle Empty Modal</Button>
-        <Modal {...args} open={open} setOpen={setOpen} />
-      </>
-    );
-  },
+  render: EmptyStory,
 };

--- a/src/common/components/Modal/index.stories.tsx
+++ b/src/common/components/Modal/index.stories.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import Modal from '.';
+import Button from '../Button'; // Button 컴포넌트
+
+const SAMPLE_TITLE = '타이틀입력 최대 한줄';
+const SAMPLE_SUBSCRIBE = '설명을 입력해주세요.';
+const SAMPLE_CANCEL = 'cancel';
+const SAMPLE_SUBMIT = 'submit';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Components/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  argTypes: {
+    open: { control: 'boolean' },
+    variant: {
+      control: 'radio',
+      options: ['default', 'empty'],
+    },
+    title: { control: 'text' },
+    subscribe: { control: 'text' },
+    cancel: { control: 'text' },
+    submit: { control: 'text' },
+  },
+  args: {
+    open: false,
+    variant: 'default',
+    title: SAMPLE_TITLE,
+    subscribe: SAMPLE_SUBSCRIBE,
+    cancel: SAMPLE_CANCEL,
+    submit: SAMPLE_SUBMIT,
+    onCancel: () => {},
+    onSubmit: () => {},
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+export const Default: Story = {
+  args: {
+    variant: 'default',
+    title: SAMPLE_TITLE,
+    subscribe: SAMPLE_SUBSCRIBE,
+    cancel: SAMPLE_CANCEL,
+    submit: SAMPLE_SUBMIT,
+  },
+
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(!open)}>Toggle Default Modal</Button>
+        <Modal
+          {...args}
+          open={open}
+          setOpen={setOpen}
+          onCancel={() => setOpen(false)}
+          onSubmit={() => {
+            alert('승인 버튼 클릭');
+            setOpen(false);
+          }}
+        />
+      </>
+    );
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    variant: 'empty',
+  },
+
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(!open)}>Toggle Empty Modal</Button>
+        <Modal {...args} open={open} setOpen={setOpen} />
+      </>
+    );
+  },
+};

--- a/src/common/components/Modal/index.style.ts
+++ b/src/common/components/Modal/index.style.ts
@@ -34,7 +34,7 @@ export const DefaultWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: ${({theme}) => theme.unit[28]};
+  gap: ${({ theme }) => theme.unit[28]};
   align-items: flex-start;
   height: 100%;
   width: 100%;

--- a/src/common/components/Modal/index.style.ts
+++ b/src/common/components/Modal/index.style.ts
@@ -37,6 +37,7 @@ export const DefaultWrapper = styled.div`
   gap: ${({theme}) => theme.unit[28]};
   align-items: flex-start;
   height: 100%;
+  width: 100%;
 `;
 
 export const TextWrapper = styled.div`

--- a/src/common/components/Modal/index.style.ts
+++ b/src/common/components/Modal/index.style.ts
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const Backdrop = styled.div`
   position: fixed;
@@ -8,15 +8,44 @@ export const Backdrop = styled.div`
   top: 0;
   background: ${({ theme }) => theme.color.primitive.base.black};
   opacity: 0.5;
+  z-index: 9998;
 `;
 
 export const ModalWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   align-items: flex-start;
-  background: ${({theme}) => theme.color.primitive.base.white};
-  color: ${({theme}) => theme.color.semantic.text.default};
-  padding: ${({theme}) => `${theme.unit[24]} ${theme.unit[20]}`};
-  border-radius: ${({theme}) => theme.radius.default};
+  background: ${({ theme }) => theme.color.primitive.base.white};
+  color: ${({ theme }) => theme.color.semantic.text.default};
+  padding: ${({ theme }) => `${theme.unit[24]} ${theme.unit[20]}`};
+  border-radius: ${({ theme }) => theme.radius.default};
+  z-index: 9999;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 83dvw;
+  height: fit-content;
+  max-width: 31rem;
+  min-width: 16.563rem;
+`;
+
+export const DefaultWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: ${({theme}) => theme.unit[28]};
+  align-items: flex-start;
+  height: 100%;
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${({ theme }) => theme.unit[16]};
+`;
+
+export const ButtonWrapper = styled.div`
+  width: 100%;
 `;

--- a/src/common/components/Modal/index.style.ts
+++ b/src/common/components/Modal/index.style.ts
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+
+export const Backdrop = styled.div`
+  position: fixed;
+  width: 100dvw;
+  height: 100dvh;
+  left: 0;
+  top: 0;
+  background: ${({ theme }) => theme.color.primitive.base.black};
+  opacity: 0.5;
+`;
+
+export const ModalWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+  background: ${({theme}) => theme.color.primitive.base.white};
+  color: ${({theme}) => theme.color.semantic.text.default};
+  padding: ${({theme}) => `${theme.unit[24]} ${theme.unit[20]}`};
+  border-radius: ${({theme}) => theme.radius.default};
+`;

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -18,7 +18,7 @@ export interface ModalProps
   onCancel?: () => void;
   onSubmit?: () => void;
   /** variant : empty인 경우에만 필요한 props */
-  _children?: ReactNode;
+  children?: ReactNode;
 }
 
 function Modal({
@@ -31,7 +31,7 @@ function Modal({
   submit,
   onCancel,
   onSubmit,
-  _children,
+  children,
   ...rest
 }: ModalProps) {
   const modalRoot = document.querySelector('#modal') as HTMLElement;
@@ -65,6 +65,7 @@ function Modal({
               </S.ButtonWrapper>
             </S.DefaultWrapper>
           )}
+          {variant === 'empty' && children}
         </S.ModalWrapper>
       </>
     ) : (

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -1,29 +1,72 @@
-import { DetailedHTMLProps, HTMLAttributes, ReactNode } from "react";
-import ReactDOM from "react-dom";
+import { DetailedHTMLProps, HTMLAttributes, ReactNode } from 'react';
+import ReactDOM from 'react-dom';
 import * as S from './index.style';
+import Text from '../Text';
+import ButtonGroup from '../ButtonGroup';
+import Button from '../Button';
 
-interface ModalProps extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>{
-  isOpen: boolean;
-  setOpen: (isOpen: false) => void;
-  children: ReactNode;
+interface ModalProps
+  extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  open: boolean;
+  setOpen: (open: false) => void;
+  variant: 'default' | 'empty';
+  /** variant : default인 경우에만 필요한 props */
+  title?: string;
+  subscribe?: string;
+  cancel?: string;
+  submit?: string;
+  onCancel?: () => void;
+  onSubmit?: () => void;
+  /** variant : empty인 경우에만 필요한 props */
+  children?: ReactNode;
 }
 
-function Modal({ isOpen = false, setOpen, children, ...rest }: ModalProps) {
-  const modalRoot = document.querySelector("#modal") as HTMLElement;
+function Modal({
+  open = false,
+  setOpen,
+  variant,
+  title,
+  subscribe,
+  cancel,
+  submit,
+  onCancel,
+  onSubmit,
+  children = null,
+  ...rest
+}: ModalProps) {
+  const modalRoot = document.querySelector('#modal') as HTMLElement;
 
   const onClose = () => {
     setOpen(false);
   };
 
   return ReactDOM.createPortal(
-    <>{
-      isOpen ? (
-        <div>
-          <S.Backdrop onClick={onClose}/>
-          <S.ModalWrapper {...rest}>{children}</S.ModalWrapper>
-        </div>
-      ): null
-    }
+    <>
+      {open ? (
+        <>
+          <S.Backdrop onClick={onClose} />
+          <S.ModalWrapper {...rest}>
+            {variant == 'default' && (
+              <S.DefaultWrapper>
+                <S.TextWrapper>
+                  <Text variant="title" color="semantic.text.strong">
+                    {title}
+                  </Text>
+                  <Text variant="body1R" color="semantic.text.strong">
+                    {subscribe}
+                  </Text>
+                </S.TextWrapper>
+                <S.ButtonWrapper>
+                <ButtonGroup direction='horizontal'>
+                  <Button onClick={onCancel} variant="secondary">{cancel}</Button>
+                  <Button onClick={onSubmit}>{submit}</Button>
+                </ButtonGroup>
+                </S.ButtonWrapper>
+              </S.DefaultWrapper>
+            )}
+          </S.ModalWrapper>
+        </>
+      ) : null}
     </>,
     modalRoot
   );

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -18,7 +18,7 @@ export interface ModalProps
   onCancel?: () => void;
   onSubmit?: () => void;
   /** variant : empty인 경우에만 필요한 props */
-  children?: ReactNode;
+  _children?: ReactNode;
 }
 
 function Modal({
@@ -31,7 +31,7 @@ function Modal({
   submit,
   onCancel,
   onSubmit,
-  children = null,
+  _children,
   ...rest
 }: ModalProps) {
   const modalRoot = document.querySelector('#modal') as HTMLElement;
@@ -41,33 +41,35 @@ function Modal({
   };
 
   return ReactDOM.createPortal(
-    <>
-      {open ? (
-        <>
-          <S.Backdrop onClick={onClose} />
-          <S.ModalWrapper {...rest}>
-            {variant == 'default' && (
-              <S.DefaultWrapper>
-                <S.TextWrapper>
-                  <Text variant="title" color="semantic.text.strong">
-                    {title}
-                  </Text>
-                  <Text variant="body1R" color="semantic.text.strong">
-                    {subscribe}
-                  </Text>
-                </S.TextWrapper>
-                <S.ButtonWrapper>
-                <ButtonGroup direction='horizontal'>
-                  <Button onClick={onCancel} variant="secondary">{cancel}</Button>
+    open ? (
+      <>
+        <S.Backdrop onClick={onClose} />
+        <S.ModalWrapper {...rest}>
+          {variant === 'default' && (
+            <S.DefaultWrapper>
+              <S.TextWrapper>
+                <Text variant="title" color="semantic.text.strong">
+                  {title}
+                </Text>
+                <Text variant="body1R" color="semantic.text.strong">
+                  {subscribe}
+                </Text>
+              </S.TextWrapper>
+              <S.ButtonWrapper>
+                <ButtonGroup direction="horizontal">
+                  <Button onClick={onCancel} variant="secondary">
+                    {cancel}
+                  </Button>
                   <Button onClick={onSubmit}>{submit}</Button>
                 </ButtonGroup>
-                </S.ButtonWrapper>
-              </S.DefaultWrapper>
-            )}
-          </S.ModalWrapper>
-        </>
-      ) : null}
-    </>,
+              </S.ButtonWrapper>
+            </S.DefaultWrapper>
+          )}
+        </S.ModalWrapper>
+      </>
+    ) : (
+      <div />
+    ),
     modalRoot
   );
 }

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -5,7 +5,7 @@ import Text from '../Text';
 import ButtonGroup from '../ButtonGroup';
 import Button from '../Button';
 
-interface ModalProps
+export interface ModalProps
   extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
   open: boolean;
   setOpen: (open: false) => void;

--- a/src/common/components/Modal/index.tsx
+++ b/src/common/components/Modal/index.tsx
@@ -1,0 +1,32 @@
+import { DetailedHTMLProps, HTMLAttributes, ReactNode } from "react";
+import ReactDOM from "react-dom";
+import * as S from './index.style';
+
+interface ModalProps extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>{
+  isOpen: boolean;
+  setOpen: (isOpen: false) => void;
+  children: ReactNode;
+}
+
+function Modal({ isOpen = false, setOpen, children, ...rest }: ModalProps) {
+  const modalRoot = document.querySelector("#modal") as HTMLElement;
+
+  const onClose = () => {
+    setOpen(false);
+  };
+
+  return ReactDOM.createPortal(
+    <>{
+      isOpen ? (
+        <div>
+          <S.Backdrop onClick={onClose}/>
+          <S.ModalWrapper {...rest}>{children}</S.ModalWrapper>
+        </div>
+      ): null
+    }
+    </>,
+    modalRoot
+  );
+}
+
+export default Modal;

--- a/src/pages/createBill/createExpenseStep/index.tsx
+++ b/src/pages/createBill/createExpenseStep/index.tsx
@@ -8,8 +8,8 @@ import FormCard from '@/pages/createBill/components/FormCard';
 import useAddExpenseFormArray from '@/pages/createBill/hooks/useAddExpenseFormArray';
 import getTotalExpense from '@/pages/createBill/utils/getTotalExpense';
 import { BillContext } from '@/pages/createBill/types/billContext.type';
-import * as S from './index.styles';
 import Modal from '@/common/components/Modal';
+import * as S from './index.styles';
 
 interface CreateExpenseStepProps
   extends BaseFunnelStepComponentProps<BillContext> {}

--- a/src/pages/createBill/createExpenseStep/index.tsx
+++ b/src/pages/createBill/createExpenseStep/index.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { FormProvider } from 'react-hook-form';
 import { Close } from '@/assets/svgs/icon';
 import Header from '@/common/components/Header';
@@ -9,6 +9,7 @@ import useAddExpenseFormArray from '@/pages/createBill/hooks/useAddExpenseFormAr
 import getTotalExpense from '@/pages/createBill/utils/getTotalExpense';
 import { BillContext } from '@/pages/createBill/types/billContext.type';
 import * as S from './index.styles';
+import Modal from '@/common/components/Modal';
 
 interface CreateExpenseStepProps
   extends BaseFunnelStepComponentProps<BillContext> {}
@@ -18,6 +19,8 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
   const { groupInfo, formMethods, defaultFormValue, fieldArrayReturns } =
     useAddExpenseFormArray();
   const mutation = useCreateExpense({ moveToNextStep });
+  const [open, setOpen] = useState<boolean>(false);
+
   useLayoutEffect(() => {
     // form의 개수가 변경되면 (추가, 삭제) 마지막 form으로 스크롤 이동
     lastFormCardRef.current?.scrollIntoView({
@@ -49,7 +52,24 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
         leftButtonContent={<Close width="1.5rem" />}
         rightButtonContent={<S.AddExpenseButton>지출 추가</S.AddExpenseButton>}
         rightButtonOnClick={handleAddExpense}
+        leftButtonOnClick={() => setOpen(true)}
       />
+      {open && (
+        <Modal
+          open={open}
+          setOpen={setOpen}
+          variant="default"
+          title="지출 내역 입력을 종료할까요?"
+          subscribe="입력한 내용은 사라지지만, 모임이 생성되어 있어 나중에 다시 추가할 수 있어요."
+          cancel="계속 입력"
+          submit="끝내기"
+          onCancel={() => setOpen(false)}
+          onSubmit={() => {
+            setOpen(false);
+            moveToNextStep?.();
+          }}
+        />
+      )}
       <S.TopWrapper>
         <S.TopMessage>
           <S.MoimName>{groupInfo.groupName}</S.MoimName>


### PR DESCRIPTION
## 📝 관련 이슈

- close #68 

## 💻 작업 내용

### 1. Modal 컴포넌트를 구현했습니다.
- React의 createPortal 훅을 이용하여 Modal 컴포넌트를 구현했습니다. [createPortal](https://ko.react.dev/reference/react-dom/createPortal)

- 컴포넌트 작업실에 나와 있는 모달 이외에도, 아무 내용 없는 모달이 필요할 것 같아 variant를 default와 empty 2개로 두었습니다.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/08fc0ee6-bd7e-4917-87be-560dda1e2391" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/11b41d69-5756-4dd0-8aa6-66b039c0edc4" />

- 완성된 Modal Props는 다음과 같습니다.
```javascript
  open: boolean;
  setOpen: (open: false) => void;
  variant: 'default' | 'empty';
  title?: string;
  subscribe?: string;
  cancel?: string; // 사용자의 행동을 취소하는 버튼의 text
  submit?: string; // 사용자의 행동을 승인하는 버튼의 text
  onCancel?: () => void; // 사용자의 행동을 취소하는 버튼의 event
  onSubmit?: () => void; // 사용자의 행동을 승인하는 버튼의 event
  children?: ReactNode;
}
```
  - `variant: 'empty'`인 경우 입력할 필요가 없는 props는 nullable로 설정했습니다. => title, subscribe, cancel, submit, onCancel, onSubmit

- 모달은 반응형으로 구현했고, 최소 너비와 최대 너비는 지원하는 디바이스 너비에 맞춰 설정했습니다. (320px, 600px)

### 2. Modal에 대한 story를 정의했습니다.
- `variant: default` , `variant: empty` 의 2개 story를 작성했습니다.
- device 크기를 다르게 해가며 봐주시면 더욱 좋습니당 🤗

### 3. CreateExpenseStep에 Modal을 연결했습니다.
- CreateExpenseStep의 header에서 왼쪽 x버튼 누르면 지출 내역 입력 종료를 묻는 모달이 나오게 만들었습니다.
- `계속 입력` 버튼을 누르면 Modal 창이 닫히고, `끝내기` 버튼을 누르면 Modal 창을 닫고 다음 step으로 이동합니다.

## 📸 스크린샷
- Modal 컴포넌트 (device-width: 320px)
![image](https://github.com/user-attachments/assets/e898d7c3-4627-41ed-b92d-a467d18d7a7d)

- CreateExpenseStep에서 Modal 작동 영상
https://github.com/user-attachments/assets/103dc8e9-964d-4b30-aa66-6f86ea05635b

<br />
