### PR TITLE
그룹 생성 플로우 API 모킹 제거

### DIFF
--- a/src/common/components/AddMember/index.tsx
+++ b/src/common/components/AddMember/index.tsx
@@ -4,7 +4,8 @@ import * as z from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Flex, Text } from '@chakra-ui/react';
 import { Member } from '@/common/types/member.type';
-import defaultProfileImg from '@/assets/pngs/defaultProfileImg.png';
+import { useLoaderData } from 'react-router';
+import useAddGroupMember from '@/common/queries/groupMembers/useAddGroupMember';
 import MemberProfile from '../MemberProfile';
 import InputGroup from '../InputGroup';
 import Input from '../Input';
@@ -23,12 +24,9 @@ interface AddMemberProps {
   onDeleteMember?: (id: number) => void; // (option) 멤버 삭제 버튼을 처리하는 함수
 }
 
-function AddMember({
-  members,
-  setMembers,
-  onAddName,
-  onDeleteMember,
-}: AddMemberProps) {
+function AddMember({ members, setMembers, onDeleteMember }: AddMemberProps) {
+  const { groupToken } = useLoaderData();
+  const mutation = useAddGroupMember(groupToken);
   const { register, handleSubmit, clearErrors, formState, reset } = useForm({
     mode: 'onChange',
     resolver: zodResolver(MemberSchema),
@@ -38,24 +36,15 @@ function AddMember({
   });
 
   /** 이름 입력 후 추가 핸들러 */
-  const handleAddName = (data: any) => {
+  const handleAddName = (data: { name: string }) => {
     const { name } = data;
-    // 이름 추가 핸들러가 있다면 실행
-    if (onAddName) {
-      onAddName(name);
-    }
-
-    // 새로운 참여자 생성 후 (필요한 경우) members 배열 직접 업데이트
-    const newMember: Member = {
-      id: Date.now(),
-      name,
-      role: 'PARTICIPANT',
-      profile: defaultProfileImg,
-      isPaid: false,
-      paidAt: null,
-    };
-
-    setMembers?.([newMember, ...members]);
+    mutation.mutate({
+      groupToken,
+      groupMemberData: {
+        name,
+        role: 'PARTICIPANT',
+      },
+    });
 
     // 초기화
     clearErrors('name');

--- a/src/common/components/AddMember/index.tsx
+++ b/src/common/components/AddMember/index.tsx
@@ -6,6 +6,7 @@ import { Flex, Text } from '@chakra-ui/react';
 import { Member } from '@/common/types/member.type';
 import { useLoaderData } from 'react-router';
 import useAddGroupMember from '@/common/queries/groupMembers/useAddGroupMember';
+import useDeleteGroupMember from '@/common/queries/groupMembers/useDeleteGroupMember';
 import MemberProfile from '../MemberProfile';
 import InputGroup from '../InputGroup';
 import Input from '../Input';
@@ -24,9 +25,10 @@ interface AddMemberProps {
   onDeleteMember?: (id: number) => void; // (option) 멤버 삭제 버튼을 처리하는 함수
 }
 
-function AddMember({ members, setMembers, onDeleteMember }: AddMemberProps) {
+function AddMember({ members }: AddMemberProps) {
   const { groupToken } = useLoaderData();
-  const mutation = useAddGroupMember(groupToken);
+  const addMutation = useAddGroupMember(groupToken);
+  const deleteMutation = useDeleteGroupMember(groupToken);
   const { register, handleSubmit, clearErrors, formState, reset } = useForm({
     mode: 'onChange',
     resolver: zodResolver(MemberSchema),
@@ -38,7 +40,7 @@ function AddMember({ members, setMembers, onDeleteMember }: AddMemberProps) {
   /** 이름 입력 후 추가 핸들러 */
   const handleAddName = (data: { name: string }) => {
     const { name } = data;
-    mutation.mutate({
+    addMutation.mutate({
       groupToken,
       groupMemberData: {
         name,
@@ -53,13 +55,7 @@ function AddMember({ members, setMembers, onDeleteMember }: AddMemberProps) {
 
   /** 참여자 제거 핸들러 */
   const handleDeleteMember = (id: number) => {
-    // 멤버 삭제 핸들러가 있다면 실행
-    if (onDeleteMember) {
-      onDeleteMember(id);
-    }
-
-    // (필요한 경우) members 배열 직접 업데이트
-    setMembers?.(members.filter((member) => member.id !== id));
+    deleteMutation.mutate({ groupToken, groupMemberId: id });
   };
 
   return (

--- a/src/common/constants/route.ts
+++ b/src/common/constants/route.ts
@@ -2,7 +2,7 @@ export const ROUTE = {
   login: '/',
   loginSuccess: '/login/success',
   home: '/home',
-  createBill: '/create-bill/:groupId',
+  createBill: '/create-bill',
   selectGroup: '/selectGroup',
   groupSetupName: '/groupSetup/groupName',
   groupSetupPassword: '/groupSetup/password',

--- a/src/common/queries/group/useGetGroupBasicInfo.ts
+++ b/src/common/queries/group/useGetGroupBasicInfo.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import group from '@/service/apis/group';
+
+const useGetGroupBasicInfo = (groupToken: string) => {
+  return useQuery({
+    queryKey: ['groupBasicInfo', groupToken],
+    queryFn: () => group.get(groupToken),
+  });
+};
+
+export default useGetGroupBasicInfo;

--- a/src/common/queries/groupMembers/useAddGroupMember.ts
+++ b/src/common/queries/groupMembers/useAddGroupMember.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import groupMembers from '@/service/apis/groupMembers';
+
+const useAddGroupMember = (groupToken: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: groupMembers.put,
+    onSuccess: () => {
+      // NOTE : 더 좋은 방법이 있을지 고민해봐야 할 것 같아요...
+      queryClient.invalidateQueries({
+        queryKey: ['groupBasicInfo', groupToken],
+      });
+    },
+    onError: (error) => {
+      console.error('Error adding group member:', error);
+    },
+  });
+};
+
+export default useAddGroupMember;

--- a/src/common/queries/groupMembers/useDeleteGroupMember.ts
+++ b/src/common/queries/groupMembers/useDeleteGroupMember.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import groupMembers from '@/service/apis/groupMembers';
+
+const useDeleteGroupMember = (groupToken: string) => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: groupMembers.delete,
+    onSuccess: () => {
+      // FIXME : 삭제 결과가 바로 적용되지 않는 문제가 있음.
+      queryClient.invalidateQueries({
+        queryKey: ['groupMembers', groupToken],
+      });
+    },
+    onError: (error) => {
+      console.error('useDeleteGroupMember: ', error);
+    },
+  });
+
+  return mutation;
+};
+
+export default useDeleteGroupMember;

--- a/src/pages/createBill/createExpenseStep/index.tsx
+++ b/src/pages/createBill/createExpenseStep/index.tsx
@@ -21,12 +21,12 @@ interface CreateExpenseStepProps
 
 function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
   const lastFormCardRef = useRef<HTMLDivElement | null>(null);
-  const { groupInfo, formMethods, defaultFormValue, fieldArrayReturns } =
-    useAddExpenseFormArray();
   const mutation = useCreateExpense({ moveToNextStep });
   const [open, setOpen] = useState<boolean>(false);
   const navigate = useNavigate();
   const { groupToken } = useLoaderData();
+  const { groupInfo, formMethods, defaultFormValue, fieldArrayReturns } =
+    useAddExpenseFormArray();
 
   useLayoutEffect(() => {
     // form의 개수가 변경되면 (추가, 삭제) 마지막 form으로 스크롤 이동
@@ -81,7 +81,7 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
         title={
           <>
             <Text variant="heading2" color="semantic.orange.default">
-              DND 7조 첫모임
+              {groupInfo.groupName}
             </Text>
             {`의\n지출 내역을 입력해주세요.`}
           </>

--- a/src/pages/createBill/hooks/useAddExpenseFormArray.ts
+++ b/src/pages/createBill/hooks/useAddExpenseFormArray.ts
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
+import { useLoaderData } from 'react-router';
 import { format } from 'date-fns';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Group } from '@/common/types/group.type';
@@ -20,13 +21,13 @@ const defaultValues: SingleExpenseForm = {
  * 지출 폼을 위한 커스텀 훅
  */
 const useAddExpenseFormArray = (initialExpense?: SingleExpenseForm) => {
+  const { groupToken } = useLoaderData();
   const [groupInfo, setGroupInfo] = useState<Group | null>(null);
   const formMethods = useForm({
     resolver: zodResolver(ExpenseFormSchema),
     mode: 'onChange', // 폼들의 필수 입력값이 모두 입력되었을 때 '다음' 버튼을 활성화시키기 위함
     defaultValues: async () => {
-      // TODO : groupToken을 받아오는 로직 추가
-      const groupData = await group.get('groupToken');
+      const groupData = await group.get(groupToken);
       setGroupInfo(groupData);
       // 기본 데이터가 있는 경우 (ex. 수정)
       if (initialExpense) {

--- a/src/service/apis/auth.ts
+++ b/src/service/apis/auth.ts
@@ -8,8 +8,6 @@ export interface GuestTokenData {
 }
 
 export const getGuestToken = async (): Promise<GuestTokenData> => {
-  const response = await axiosInstance.get('/user/guest/token', {
-    useMock: true,
-  });
+  const response = await axiosInstance.get('/user/guest/token');
   return response.data;
 };

--- a/src/service/apis/group.ts
+++ b/src/service/apis/group.ts
@@ -8,9 +8,7 @@ import axiosInstance from './axios';
 const group = {
   get: (groupToken: string): Promise<Group> =>
     axiosInstance
-      .get(`/group?groupToken=${groupToken}`, {
-        useMock: true,
-      })
+      .get(`/group?groupToken=${groupToken}`)
       .then((res) => res.data),
 
   post: async (groupData: CreateGroupData) => {

--- a/src/service/apis/group.ts
+++ b/src/service/apis/group.ts
@@ -14,9 +14,7 @@ const group = {
       .then((res) => res.data),
 
   post: async (groupData: CreateGroupData) => {
-    const response = await axiosInstance.post('/group', groupData, {
-      useMock: true,
-    });
+    const response = await axiosInstance.post('/group', groupData);
     return response.data;
   },
 

--- a/src/service/apis/groupMembers.ts
+++ b/src/service/apis/groupMembers.ts
@@ -7,18 +7,18 @@ export interface CreateGroupMembersVariable {
 
 const groupMembers = {
   // NOTE : 사용하지 않는 API인지 확인 필요합니다.
-  // /** body에 {name: string}[] 을 전달해야 하며, 총무는 제외한다. */
-  // post: async (groupMemberData: CreateGroupMembersVariable[]) => {
-  //   const groupToken = localStorage.getItem('groupToken');
-  //   const response = await axiosInstance.post(
-  //     `/group-members?groupToken=${groupToken}`,
-  //     { members: groupMemberData },
-  //     {
-  //       useMock: true,
-  //     }
-  //   );
-  //   return response.data.members;
-  // },
+  /** body에 {name: string}[] 을 전달해야 하며, 총무는 제외한다. */
+  post: async (groupMemberData: CreateGroupMembersVariable[]) => {
+    const groupToken = localStorage.getItem('groupToken');
+    const response = await axiosInstance.post(
+      `/group-members?groupToken=${groupToken}`,
+      { members: groupMemberData },
+      {
+        useMock: true,
+      }
+    );
+    return response.data.members;
+  },
   // PUT addGroupMember
   put: async ({
     groupMemberData,

--- a/src/service/apis/groupMembers.ts
+++ b/src/service/apis/groupMembers.ts
@@ -1,3 +1,4 @@
+import { Member, MemberData } from '@/common/types/member.type';
 import axiosInstance from './axios';
 
 export interface CreateGroupMembersVariable {
@@ -5,17 +6,32 @@ export interface CreateGroupMembersVariable {
 }
 
 const groupMembers = {
-  /** body에 {name: string}[] 을 전달해야 하며, 총무는 제외한다. */
-  post: async (groupMemberData: CreateGroupMembersVariable[]) => {
-    const groupToken = localStorage.getItem('groupToken');
-    const response = await axiosInstance.post(
+  // NOTE : 사용하지 않는 API인지 확인 필요합니다.
+  // /** body에 {name: string}[] 을 전달해야 하며, 총무는 제외한다. */
+  // post: async (groupMemberData: CreateGroupMembersVariable[]) => {
+  //   const groupToken = localStorage.getItem('groupToken');
+  //   const response = await axiosInstance.post(
+  //     `/group-members?groupToken=${groupToken}`,
+  //     { members: groupMemberData },
+  //     {
+  //       useMock: true,
+  //     }
+  //   );
+  //   return response.data.members;
+  // },
+  // PUT addGroupMember
+  put: async ({
+    groupMemberData,
+    groupToken,
+  }: {
+    groupMemberData: MemberData;
+    groupToken: string;
+  }) => {
+    const response = await axiosInstance.put<Member>(
       `/group-members?groupToken=${groupToken}`,
-      { members: groupMemberData },
-      {
-        useMock: true,
-      }
+      groupMemberData
     );
-    return response.data.members;
+    return response.data;
   },
 };
 

--- a/src/service/apis/groupMembers.ts
+++ b/src/service/apis/groupMembers.ts
@@ -33,6 +33,19 @@ const groupMembers = {
     );
     return response.data;
   },
+  // DELETE deleteGroupMember
+  delete: async ({
+    groupToken,
+    groupMemberId,
+  }: {
+    groupToken: string;
+    groupMemberId: number;
+  }) => {
+    const response = await axiosInstance.delete(
+      `/group-members/${groupMemberId}?groupToken=${groupToken}`
+    );
+    return response.data;
+  },
 };
 
 export default groupMembers;


### PR DESCRIPTION
## 📝 관련 이슈

- #80

## 💻 작업 내용

### 그룹 생성 플로우 API 모킹 제거

- 게스트 토큰 발급
- 그룹 생성
- 그룹 조회
- 참여자 추가
- 참여자 삭제
- 참여자 조회 (그룹 정보 조회 API 활용)

AddMember 컴포넌트가 결국에는 기능이 동일하게 되면서 (여은님 선견지명... 👍) prop로 전달하던 핸들러 대신 내부에서 api 요청하도록 변경했습니다. (아직 지출 폼 쪽이랑 엮여 있어서 props 타입을 바꾸진 않았습니당)

### 코멘트 설명

한명씩 업데이트하면서 그 업데이트한 결과를 랜더링하기 위해서 쿼리 무효화를 시켰는데요, 요청이 너무 많이 가는 문제가 있어서 더 좋은 방법을 찾아봐야 할 것 같습니다..

https://github.com/dnd-side-project/dnd-12th-7-frontend/blob/880c5acd73a9023a776b919b68504f63d3f91d7d/src/common/queries/groupMembers/useAddGroupMember.ts#L4-L13

추가와 마찬가지로 삭제 시에도 쿼리 무효화를 시켰는데, 바로 재요청을 보내지 않아서 업데이트가 바로 되지 않는 문제가 있습니당... (위에 문제와 함께 해결할 수 있을 듯 합니다!)

https://github.com/dnd-side-project/dnd-12th-7-frontend/blob/880c5acd73a9023a776b919b68504f63d3f91d7d/src/common/queries/groupMembers/useDeleteGroupMember.ts#L4-L13

현재는 총무가 그룹 생성 직후에 생성되지 않아서 임의로 넣어줬는데 아마 백엔드 API 작업사항 추가로 반영되면 이 부분은 제거해야 할 듯 합니다!

https://github.com/dnd-side-project/dnd-12th-7-frontend/blob/880c5acd73a9023a776b919b68504f63d3f91d7d/src/pages/groupSetup/memberSetup/index.tsx#L64-L65
