### PR TITLE
지출 추가 페이지의 참여자 추가 기능 보완

### DIFF
--- a/src/common/components/BottomSheet/index.tsx
+++ b/src/common/components/BottomSheet/index.tsx
@@ -10,6 +10,7 @@ export interface BottomSheetProps {
   children: ReactNode;
   isPadding?: boolean;
   pb?: number;
+  onCloseHandler?: () => void;
 }
 
 function BottomSheet({
@@ -18,6 +19,7 @@ function BottomSheet({
   children,
   isPadding = false,
   pb,
+  onCloseHandler,
   ...rest
 }: BottomSheetProps) {
   const bottomSheetRoot = document.querySelector(
@@ -33,6 +35,7 @@ function BottomSheet({
   }, [open]);
 
   const onClose = () => {
+    onCloseHandler?.();
     setOpen(false);
   };
 

--- a/src/pages/createBill/addExpenseStep/index.tsx
+++ b/src/pages/createBill/addExpenseStep/index.tsx
@@ -13,7 +13,7 @@ interface AddExpenseStepProps
   extends BaseFunnelStepComponentProps<BillContext> {}
 
 function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
-  const { groupInfo, formMethods, fieldArrayReturns } =
+  const { groupInfo, formMethods, fieldArrayReturns, setGroupInfo } =
     useAddExpenseFormArray();
   const { groupToken } = useLoaderData();
   const mutation = useCreateExpense({ moveToNextStep, groupToken });
@@ -40,7 +40,12 @@ function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
       </S.TopWrapper>
       <S.BillFormList>
         {fieldArrayReturns.fields.map((field, index) => (
-          <FormCard key={field.id} ref={null} index={index} />
+          <FormCard
+            key={field.id}
+            ref={null}
+            index={index}
+            setGroupInfo={setGroupInfo}
+          />
         ))}
       </S.BillFormList>
       <S.ButtonWrapper>

--- a/src/pages/createBill/components/FormCard/index.tsx
+++ b/src/pages/createBill/components/FormCard/index.tsx
@@ -15,16 +15,18 @@ import FormField from '@/pages/createBill/components/FormField';
 import NumPadBottomSheet from '@/pages/createBill/components/NumPadBottomSheet';
 import MemberBottomSheet from '@/pages/createBill/components/MemberBottomSheet';
 import MemberExpenses from '@/pages/createBill/components/MemberExpenses';
+import { Group } from '@/common/types/group.type';
 import 'react-datepicker/dist/react-datepicker.css';
 import * as S from './index.styles';
 
 interface FormCardProps {
   index: number;
   onDelete?: (index: number) => void; // 폼 삭제 버튼 클릭 시 호출되는 함수
+  setGroupInfo: (groupInfo: Group) => void; // 참여자 추가 시에 그룹 정보를 업데이트하는 함수
 }
 
 const FormCard = forwardRef<HTMLDivElement, FormCardProps>(
-  ({ index, onDelete }, ref) => {
+  ({ index, onDelete, setGroupInfo }, ref) => {
     const { register, watch, setValue, control } = useFormContext();
     const [openNumPad, setOpenNumPad] = useState(false);
     const [openMemberSheet, setOpenMemberSheet] = useState(false);
@@ -152,6 +154,7 @@ const FormCard = forwardRef<HTMLDivElement, FormCardProps>(
         <MemberBottomSheet
           open={openMemberSheet}
           setOpen={setOpenMemberSheet}
+          setGroupInfo={setGroupInfo}
         />
       </>
     );

--- a/src/pages/createBill/components/MemberBottomSheet/index.tsx
+++ b/src/pages/createBill/components/MemberBottomSheet/index.tsx
@@ -4,16 +4,28 @@ import { Text, Stack } from '@chakra-ui/react';
 import AddMember from '@/common/components/AddMember';
 import BottomSheet from '@/common/components/BottomSheet';
 import useGetGroupBasicInfo from '@/common/queries/group/useGetGroupBasicInfo';
+import { Group } from '@/common/types/group.type';
 
 interface MemberBottomSheetProps {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
   // groupId: number;
+  setGroupInfo: (groupInfo: Group) => void; // 참여자 정보가 바뀔 때 모아서 업데이트하는 함수
 }
 
-function MemberBottomSheet({ open, setOpen }: MemberBottomSheetProps) {
+function MemberBottomSheet({
+  open,
+  setOpen,
+  setGroupInfo,
+}: MemberBottomSheetProps) {
   const { groupToken } = useLoaderData();
   const { data, isLoading, isError } = useGetGroupBasicInfo(groupToken);
+
+  const onCloseHandler = () => {
+    if (data) {
+      setGroupInfo(data);
+    }
+  };
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -24,7 +36,7 @@ function MemberBottomSheet({ open, setOpen }: MemberBottomSheetProps) {
   }
 
   return (
-    <BottomSheet open={open} setOpen={setOpen}>
+    <BottomSheet open={open} setOpen={setOpen} onCloseHandler={onCloseHandler}>
       <Stack
         paddingTop="2rem"
         paddingBottom="1.75rem"

--- a/src/pages/createBill/createExpenseStep/index.tsx
+++ b/src/pages/createBill/createExpenseStep/index.tsx
@@ -25,8 +25,13 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
   const mutation = useCreateExpense({ moveToNextStep, groupToken });
   const [open, setOpen] = useState<boolean>(false);
   const navigate = useNavigate();
-  const { groupInfo, formMethods, defaultFormValue, fieldArrayReturns } =
-    useAddExpenseFormArray();
+  const {
+    groupInfo,
+    formMethods,
+    defaultFormValue,
+    fieldArrayReturns,
+    setGroupInfo,
+  } = useAddExpenseFormArray();
 
   useLayoutEffect(() => {
     // form의 개수가 변경되면 (추가, 삭제) 마지막 form으로 스크롤 이동
@@ -99,6 +104,7 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
             }
             index={index}
             onDelete={handleDeleteExpense}
+            setGroupInfo={setGroupInfo}
           />
         ))}
       </S.BillFormList>

--- a/src/pages/createBill/editExpenseStep/index.tsx
+++ b/src/pages/createBill/editExpenseStep/index.tsx
@@ -21,7 +21,7 @@ function EditExpenseStep({
   initialExpense,
   moveToNextStep,
 }: EditExpenseStepProps) {
-  const { groupInfo, formMethods, fieldArrayReturns } =
+  const { groupInfo, formMethods, fieldArrayReturns, setGroupInfo } =
     useAddExpenseFormArray(initialExpense);
   const { groupToken } = useLoaderData();
   const mutation = useUpdateExpense({ moveToNextStep, groupToken });
@@ -48,7 +48,12 @@ function EditExpenseStep({
       </S.TopWrapper>
       <S.BillFormList>
         {fieldArrayReturns.fields.map((field, index) => (
-          <FormCard key={field.id} ref={null} index={index} />
+          <FormCard
+            key={field.id}
+            ref={null}
+            index={index}
+            setGroupInfo={setGroupInfo}
+          />
         ))}
       </S.BillFormList>
       <S.ButtonWrapper>

--- a/src/pages/createBill/hooks/useAddExpenseFormArray.ts
+++ b/src/pages/createBill/hooks/useAddExpenseFormArray.ts
@@ -52,6 +52,7 @@ const useAddExpenseFormArray = (initialExpense?: SingleExpenseForm) => {
       };
     },
   });
+
   const defaultFormValue = useMemo(() => {
     if (!groupInfo) {
       return defaultValues;
@@ -67,6 +68,7 @@ const useAddExpenseFormArray = (initialExpense?: SingleExpenseForm) => {
       })),
     };
   }, [groupInfo]);
+
   const fieldArrayReturns = useFieldArray({
     control: formMethods.control,
     name: 'expenses',
@@ -77,6 +79,7 @@ const useAddExpenseFormArray = (initialExpense?: SingleExpenseForm) => {
     formMethods,
     defaultFormValue,
     fieldArrayReturns,
+    setGroupInfo,
   };
 };
 


### PR DESCRIPTION
## 📝 관련 이슈

- #90

## 💻 작업 내용

지출 추가 페이지의 참여자 추가 기능을 일부 보완했습니다...

### 새로운 폼에 새로운 참여자가 반영되도록 함

참여자 추가 바텀시트에서 참여자를 추가한 뒤에, 바텀시트를 닫으면 해당 데이터를 폼의 기본값으로 적용하도록 설정했습니다.

- 바텀시트가 닫힐 때 핸들러를 호출할 수 있도록 onCloseHandler props를 추가했습니다.
- 참여자를 추가한 뒤에 바텀시트를 닫으면, 최신 참여자 목록을 가지고 폼의 기본 값을 설정합니다. (다른 곳과 동일하게 여기서도 참여자 삭제 시에 리페치가 일어나지 않아서 데이터가 최신화되지 않는 문제가 남아 있습니다..)

### 구현 안된 사항과 논의점

#### 1. 기존 폼을 수정하기 (구현 x)

기존 폼을 수정하는 로직이 너무너무너무너무너무 복잡해서 이 설계가 맞는지 의문이 들 정도라 지금은 구현하지 않았습니다..
만약에 구현한다면
1. 모든 폼을 순회하면서 아래 단계를 수행
2. 최신 참여자 정보와 기존 폼의 정보를 확인
3. 폼에는 없지만 참여자 정보에는 있는 유저를 처리 (아래 경우를 판단하는 방법은,,, 아직 잘 모르겠습니다....)
   - 바텀시트에서 완전히 새로 추가된 유저인지 => 새로 추가한다
   - 폼에서 x 표시로 제거했던 유저인지 => 그냥 둔다
4. 폼에는 있지만 참여자 정보에는 없는 유저를 제거

#### 2. 기존 폼을 유지하는 지금의 상황에서 발생할 수 있는 문제점

지금 방식은 기존 폼을 유지하고 생성되는 새로운 폼에 변경된 참여자를 반영해주는 방식인데요.
참여자를 추가할 때에는 이런 방식이 나름 괜찮을 것 같은데,
참여자를 삭제할 경우에는 **삭제된 참여자가 이미 생성된 폼에는 여전히 남아있는 문제**가 있습니다.
**지금 추가한 방식을 적용해도 괜찮을지,,, 잘 모르겠습니다 ㅜㅜ**

## 📸 스크린샷

https://github.com/user-attachments/assets/98693b7a-86a2-4d14-8ab0-bd49dce5bed1

## 👻 리뷰 요구사항

어제 모바일에서 테스트해보니까 저희 입력창이 많은데 auto complete까지 떠서 좀 불편하더라구요
auto-complete=false 설정을 공통 컴포넌트 input에 붙이는게 어떨지... 의견드립니다..ㅎㅎ
https://dogfoothard.tistory.com/120
