### PR TITLE
지출 참여자 관련 QA 반영

### DIFF
--- a/src/common/queries/groupMembers/useDeleteGroupMember.ts
+++ b/src/common/queries/groupMembers/useDeleteGroupMember.ts
@@ -6,9 +6,8 @@ const useDeleteGroupMember = (groupToken: string) => {
   const mutation = useMutation({
     mutationFn: groupMembers.delete,
     onSuccess: () => {
-      // FIXME : 삭제 결과가 바로 적용되지 않는 문제가 있음.
       queryClient.invalidateQueries({
-        queryKey: ['groupMembers', groupToken],
+        queryKey: ['groupBasicInfo', groupToken],
       });
     },
     onError: (error) => {

--- a/src/pages/createBill/addExpenseStep/index.tsx
+++ b/src/pages/createBill/addExpenseStep/index.tsx
@@ -13,7 +13,7 @@ interface AddExpenseStepProps
   extends BaseFunnelStepComponentProps<BillContext> {}
 
 function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
-  const { groupInfo, formMethods, fieldArrayReturns, setGroupInfo } =
+  const { groupInfo, formMethods, fieldArrayReturns } =
     useAddExpenseFormArray();
   const { groupToken } = useLoaderData();
   const mutation = useCreateExpense({ moveToNextStep, groupToken });
@@ -40,12 +40,7 @@ function AddExpenseStep({ moveToNextStep }: AddExpenseStepProps) {
       </S.TopWrapper>
       <S.BillFormList>
         {fieldArrayReturns.fields.map((field, index) => (
-          <FormCard
-            key={field.id}
-            ref={null}
-            index={index}
-            setGroupInfo={setGroupInfo}
-          />
+          <FormCard key={field.id} ref={null} index={index} />
         ))}
       </S.BillFormList>
       <S.ButtonWrapper>

--- a/src/pages/createBill/components/FormCard/index.tsx
+++ b/src/pages/createBill/components/FormCard/index.tsx
@@ -13,23 +13,20 @@ import BillDatePicker from '@/common/components/DatePicker';
 import Text from '@/common/components/Text';
 import FormField from '@/pages/createBill/components/FormField';
 import NumPadBottomSheet from '@/pages/createBill/components/NumPadBottomSheet';
-import MemberBottomSheet from '@/pages/createBill/components/MemberBottomSheet';
 import MemberExpenses from '@/pages/createBill/components/MemberExpenses';
-import { Group } from '@/common/types/group.type';
 import 'react-datepicker/dist/react-datepicker.css';
 import * as S from './index.styles';
 
 interface FormCardProps {
   index: number;
   onDelete?: (index: number) => void; // 폼 삭제 버튼 클릭 시 호출되는 함수
-  setGroupInfo: (groupInfo: Group) => void; // 참여자 추가 시에 그룹 정보를 업데이트하는 함수
 }
 
 const FormCard = forwardRef<HTMLDivElement, FormCardProps>(
-  ({ index, onDelete, setGroupInfo }, ref) => {
+  ({ index, onDelete }, ref) => {
     const { register, watch, setValue, control } = useFormContext();
     const [openNumPad, setOpenNumPad] = useState(false);
-    const [openMemberSheet, setOpenMemberSheet] = useState(false);
+    // const [openMemberSheet, setOpenMemberSheet] = useState(false);
     const [remainderData, setRemainderData] = useState<RemainderData | null>(
       null
     );
@@ -76,87 +73,87 @@ const FormCard = forwardRef<HTMLDivElement, FormCardProps>(
     }, [amount, index, memberExpenses, setValue]);
 
     return (
-      <>
-        <S.FormCard ref={ref}>
-          <S.FormCardTitleContainer>
-            <Text variant="title">{index + 1}차</Text>
-            {index > 0 ? (
-              <Button variant="text" onClick={() => onDelete?.(index)}>
-                <Close width="1.5rem" />
-              </Button>
-            ) : null}
-          </S.FormCardTitleContainer>
-          <S.FormContainer>
-            <FormField
-              label="지출 금액"
-              required
-              control={control}
-              name={`expenses.${index}.amount`}
-              renderInput={({ field }) => (
-                <NumPadBottomSheet
-                  initialValue={field.value}
-                  open={openNumPad}
-                  setOpen={setOpenNumPad}
-                  setValue={(value) => field.onChange(value)}
-                />
-              )}
-            />
-            <FormField
-              label="지출 장소 및 내용"
-              required
-              register={register(`expenses.${index}.content`)}
-              name={`expenses.${index}.content`}
-              placeholder="ex. 투썸플레이스"
-            />
-            <FormField
-              label="지출일"
-              control={control}
-              name={`expenses.${index}.date`}
-              renderInput={({ field }) => (
-                <BillDatePicker
-                  selected={new Date(field.value)}
-                  onChange={(date) =>
-                    field.onChange(format(date || new Date(), 'yyyy-MM-dd'))
-                  }
-                />
-              )}
-            />
-            <FormField
-              label="참여자"
-              name={`expenses.${index}.memberExpenses`}
-              control={control}
-              subButton={{
-                label: '참여자 추가',
-                onClick: () => setOpenMemberSheet(true),
-              }}
-              renderInput={({ field }) => (
-                <>
-                  {remainderData ? (
-                    <Alert
-                      type="info"
-                      message={`${remainderData.name}님에게 남은 ${remainderData.remainder}원이 부과됐어요.`}
-                    />
-                  ) : null}
-                  <MemberExpenses
-                    members={field.value}
-                    onDelete={(name) => {
-                      const newMembers = field.value.filter(
-                        (member: ExpenseFormMember) => member.name !== name
-                      );
-                      field.onChange(newMembers);
-                    }}
+      // <>
+      <S.FormCard ref={ref}>
+        <S.FormCardTitleContainer>
+          <Text variant="title">{index + 1}차</Text>
+          {index > 0 ? (
+            <Button variant="text" onClick={() => onDelete?.(index)}>
+              <Close width="1.5rem" />
+            </Button>
+          ) : null}
+        </S.FormCardTitleContainer>
+        <S.FormContainer>
+          <FormField
+            label="지출 금액"
+            required
+            control={control}
+            name={`expenses.${index}.amount`}
+            renderInput={({ field }) => (
+              <NumPadBottomSheet
+                initialValue={field.value}
+                open={openNumPad}
+                setOpen={setOpenNumPad}
+                setValue={(value) => field.onChange(value)}
+              />
+            )}
+          />
+          <FormField
+            label="지출 장소 및 내용"
+            required
+            register={register(`expenses.${index}.content`)}
+            name={`expenses.${index}.content`}
+            placeholder="ex. 투썸플레이스"
+          />
+          <FormField
+            label="지출일"
+            control={control}
+            name={`expenses.${index}.date`}
+            renderInput={({ field }) => (
+              <BillDatePicker
+                selected={new Date(field.value)}
+                onChange={(date) =>
+                  field.onChange(format(date || new Date(), 'yyyy-MM-dd'))
+                }
+              />
+            )}
+          />
+          <FormField
+            label="참여자"
+            name={`expenses.${index}.memberExpenses`}
+            control={control}
+            // subButton={{
+            //   label: '참여자 추가',
+            //   onClick: () => setOpenMemberSheet(true),
+            // }}
+            renderInput={({ field }) => (
+              <>
+                {remainderData ? (
+                  <Alert
+                    type="info"
+                    message={`${remainderData.name}님에게 남은 ${remainderData.remainder}원이 부과됐어요.`}
                   />
-                </>
-              )}
-            />
-          </S.FormContainer>
-        </S.FormCard>
-        <MemberBottomSheet
-          open={openMemberSheet}
-          setOpen={setOpenMemberSheet}
-          setGroupInfo={setGroupInfo}
-        />
-      </>
+                ) : null}
+                <MemberExpenses
+                  members={field.value}
+                  onDelete={(name) => {
+                    const newMembers = field.value.filter(
+                      (member: ExpenseFormMember) => member.name !== name
+                    );
+                    field.onChange(newMembers);
+                  }}
+                />
+              </>
+            )}
+          />
+        </S.FormContainer>
+      </S.FormCard>
+      // <MemberBottomSheet
+      //   open={openMemberSheet}
+      //   setOpen={setOpenMemberSheet}
+      //   setGroupInfo={setGroupInfo}
+      // />
+      // </>
     );
   }
 );

--- a/src/pages/createBill/components/MemberExpenses/index.tsx
+++ b/src/pages/createBill/components/MemberExpenses/index.tsx
@@ -20,9 +20,11 @@ function MemberExpenses({ members, onDelete }: MemberExpensesProps) {
                 src={member.profile}
                 alt={`${member.name} 프로필 이미지`}
               />
-              <S.DeleteButtonWrapper onClick={() => onDelete(member.name)}>
-                <SystemDanger width="0.83331rem" />
-              </S.DeleteButtonWrapper>
+              {members.length > 1 ? (
+                <S.DeleteButtonWrapper onClick={() => onDelete(member.name)}>
+                  <SystemDanger width="0.83331rem" />
+                </S.DeleteButtonWrapper>
+              ) : null}
             </S.ProfileWrapper>
             <Text variant="caption">{member.name}</Text>
           </S.ProfileContainer>

--- a/src/pages/createBill/createExpenseStep/index.tsx
+++ b/src/pages/createBill/createExpenseStep/index.tsx
@@ -25,13 +25,8 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
   const mutation = useCreateExpense({ moveToNextStep, groupToken });
   const [open, setOpen] = useState<boolean>(false);
   const navigate = useNavigate();
-  const {
-    groupInfo,
-    formMethods,
-    defaultFormValue,
-    fieldArrayReturns,
-    setGroupInfo,
-  } = useAddExpenseFormArray();
+  const { groupInfo, formMethods, defaultFormValue, fieldArrayReturns } =
+    useAddExpenseFormArray();
 
   useLayoutEffect(() => {
     // form의 개수가 변경되면 (추가, 삭제) 마지막 form으로 스크롤 이동
@@ -104,7 +99,6 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
             }
             index={index}
             onDelete={handleDeleteExpense}
-            setGroupInfo={setGroupInfo}
           />
         ))}
       </S.BillFormList>

--- a/src/pages/createBill/editExpenseStep/index.tsx
+++ b/src/pages/createBill/editExpenseStep/index.tsx
@@ -21,7 +21,7 @@ function EditExpenseStep({
   initialExpense,
   moveToNextStep,
 }: EditExpenseStepProps) {
-  const { groupInfo, formMethods, fieldArrayReturns, setGroupInfo } =
+  const { groupInfo, formMethods, fieldArrayReturns } =
     useAddExpenseFormArray(initialExpense);
   const { groupToken } = useLoaderData();
   const mutation = useUpdateExpense({ moveToNextStep, groupToken });
@@ -48,12 +48,7 @@ function EditExpenseStep({
       </S.TopWrapper>
       <S.BillFormList>
         {fieldArrayReturns.fields.map((field, index) => (
-          <FormCard
-            key={field.id}
-            ref={null}
-            index={index}
-            setGroupInfo={setGroupInfo}
-          />
+          <FormCard key={field.id} ref={null} index={index} />
         ))}
       </S.BillFormList>
       <S.ButtonWrapper>

--- a/src/pages/createBill/hooks/useAddExpenseFormArray.ts
+++ b/src/pages/createBill/hooks/useAddExpenseFormArray.ts
@@ -79,7 +79,6 @@ const useAddExpenseFormArray = (initialExpense?: SingleExpenseForm) => {
     formMethods,
     defaultFormValue,
     fieldArrayReturns,
-    setGroupInfo,
   };
 };
 


### PR DESCRIPTION
## 📝 관련 이슈

- close #99 

## 💻 작업 내용

### 1. 지출 폼에서 참여자 추가 버튼을 제거했습니다

아예 관련 코드를 제거하는 것 보다는 (별로 좋아하는 방법은 아니지만,,) 나중을 위해 남겨두는 것이 좋을 것 같아서 참여자 추가 바텀시트 코드는 삭제하지 않고 해당 컴포넌트가 사용되던 곳을 지웠습니다!

### 2. 참여자가 1명인 경우에는 제거 버튼이 보이지 않도록 했습니다

총무를 무조건 지출에 포함시키는 것 보다 누구든 적어도 한명은 지출에 포함될 수 있도록 하는 것이 첫번째 대안이었는데, 구현이 그렇게 어렵지 않아서 이 방식으로 처리했습니당

### 3. 참여자를 삭제한 경우에 리페치해오지 않는 문제를 해결했습니다.

원인은 바로............
...
...
쿼리 키 불일치 문제였습니다!!!!!!! 🥹🥳🥹🎉
조회와 추가에서는 'groupBasicInfo' 키를 사용하고 있었고, 삭제에서는 'groupMembers'를 무효화시키고 있었으니,,, 당연히 리페치가 안되는거였네요 ㅎㅎ 퀵 해결이 가능한 문제였어서 다행입니다!!!!

(쿼리 키 관리 대책을 좀 마련해야겠네요........)

## 📸 스크린샷

| 참여자 추가 버튼 제거 | 참여자가 1명인 경우 제거버튼 없애기 | 삭제 시 리페치해오기 |
| --- | --- | --- |
| <img width="371" alt="Screen_Shot 2025-02-21 20 06 12" src="https://github.com/user-attachments/assets/c9c0ee2d-c814-4dad-8b4a-3ddd2d9d42e3" /> | <video src="https://github.com/user-attachments/assets/e2d77cb9-78fb-4b78-a244-d3f86d12e34a"> | <video src="https://github.com/user-attachments/assets/9116e616-76fb-4283-96ed-2eaf1e1a5942"> |
