### PR TITLE
모임/지출 생성 UI 관련 QA 반영

### DIFF
--- a/src/common/components/Input/index.styles.ts
+++ b/src/common/components/Input/index.styles.ts
@@ -86,4 +86,9 @@ export const Input = styled.input`
   &::placeholder {
     opacity: 0.5;
   }
+  min-width: 0;
+`;
+
+export const IconWrapper = styled.div`
+  flex-shrink: 0;
 `;

--- a/src/common/components/Input/index.styles.ts
+++ b/src/common/components/Input/index.styles.ts
@@ -7,6 +7,7 @@ export const Container = styled.div`
   align-items: flex-start;
   gap: ${({ theme }) => theme.unit[8]};
   width: 100%;
+  min-width: 0;
 `;
 
 export const LabelField = styled.div`

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -47,7 +47,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             disabled={disabled}
             {...props}
           />
-          {icon}
+          <S.IconWrapper>{icon}</S.IconWrapper>
         </S.Wrapper>
       </S.Container>
     );

--- a/src/pages/createBill/addExpenseStep/index.styles.ts
+++ b/src/pages/createBill/addExpenseStep/index.styles.ts
@@ -7,7 +7,8 @@ export const BillFormList = styled.form`
   width: 100%;
   flex: 1 0 0;
   overflow-y: auto;
-  padding: ${({ theme }) => `${theme.unit[24]} ${theme.unit[20]}`};
+  padding: ${({ theme }) =>
+    `0 ${theme.unit[20]} ${theme.unit[24]} ${theme.unit[20]}`};
   background: ${({ theme }) =>
     theme.color.semantic.background.normal.alternative};
 `;

--- a/src/pages/createBill/components/FormCard/index.styles.ts
+++ b/src/pages/createBill/components/FormCard/index.styles.ts
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
 
+export const RefTarget = styled.div`
+  height: ${({ theme }) => theme.unit[24]};
+`;
+
 export const FormCard = styled.div`
   display: flex;
   padding: 1.25rem;

--- a/src/pages/createBill/components/FormCard/index.tsx
+++ b/src/pages/createBill/components/FormCard/index.tsx
@@ -73,87 +73,88 @@ const FormCard = forwardRef<HTMLDivElement, FormCardProps>(
     }, [amount, index, memberExpenses, setValue]);
 
     return (
-      // <>
-      <S.FormCard ref={ref}>
-        <S.FormCardTitleContainer>
-          <Text variant="title">{index + 1}차</Text>
-          {index > 0 ? (
-            <Button variant="text" onClick={() => onDelete?.(index)}>
-              <Close width="1.5rem" />
-            </Button>
-          ) : null}
-        </S.FormCardTitleContainer>
-        <S.FormContainer>
-          <FormField
-            label="지출 금액"
-            required
-            control={control}
-            name={`expenses.${index}.amount`}
-            renderInput={({ field }) => (
-              <NumPadBottomSheet
-                initialValue={field.value}
-                open={openNumPad}
-                setOpen={setOpenNumPad}
-                setValue={(value) => field.onChange(value)}
-              />
-            )}
-          />
-          <FormField
-            label="지출 장소 및 내용"
-            required
-            register={register(`expenses.${index}.content`)}
-            name={`expenses.${index}.content`}
-            placeholder="ex. 투썸플레이스"
-          />
-          <FormField
-            label="지출일"
-            control={control}
-            name={`expenses.${index}.date`}
-            renderInput={({ field }) => (
-              <BillDatePicker
-                selected={new Date(field.value)}
-                onChange={(date) =>
-                  field.onChange(format(date || new Date(), 'yyyy-MM-dd'))
-                }
-              />
-            )}
-          />
-          <FormField
-            label="참여자"
-            name={`expenses.${index}.memberExpenses`}
-            control={control}
-            // subButton={{
-            //   label: '참여자 추가',
-            //   onClick: () => setOpenMemberSheet(true),
-            // }}
-            renderInput={({ field }) => (
-              <>
-                {remainderData ? (
-                  <Alert
-                    type="info"
-                    message={`${remainderData.name}님에게 남은 ${remainderData.remainder}원이 부과됐어요.`}
-                  />
-                ) : null}
-                <MemberExpenses
-                  members={field.value}
-                  onDelete={(name) => {
-                    const newMembers = field.value.filter(
-                      (member: ExpenseFormMember) => member.name !== name
-                    );
-                    field.onChange(newMembers);
-                  }}
+      <>
+        <S.RefTarget ref={ref} />
+        <S.FormCard>
+          <S.FormCardTitleContainer>
+            <Text variant="title">{index + 1}차</Text>
+            {index > 0 ? (
+              <Button variant="text" onClick={() => onDelete?.(index)}>
+                <Close width="1.5rem" />
+              </Button>
+            ) : null}
+          </S.FormCardTitleContainer>
+          <S.FormContainer>
+            <FormField
+              label="지출 금액"
+              required
+              control={control}
+              name={`expenses.${index}.amount`}
+              renderInput={({ field }) => (
+                <NumPadBottomSheet
+                  initialValue={field.value}
+                  open={openNumPad}
+                  setOpen={setOpenNumPad}
+                  setValue={(value) => field.onChange(value)}
                 />
-              </>
-            )}
-          />
-        </S.FormContainer>
-      </S.FormCard>
-      // <MemberBottomSheet
+              )}
+            />
+            <FormField
+              label="지출 장소 및 내용"
+              required
+              register={register(`expenses.${index}.content`)}
+              name={`expenses.${index}.content`}
+              placeholder="ex. 투썸플레이스"
+            />
+            <FormField
+              label="지출일"
+              control={control}
+              name={`expenses.${index}.date`}
+              renderInput={({ field }) => (
+                <BillDatePicker
+                  selected={new Date(field.value)}
+                  onChange={(date) =>
+                    field.onChange(format(date || new Date(), 'yyyy-MM-dd'))
+                  }
+                />
+              )}
+            />
+            <FormField
+              label="참여자"
+              name={`expenses.${index}.memberExpenses`}
+              control={control}
+              // subButton={{
+              //   label: '참여자 추가',
+              //   onClick: () => setOpenMemberSheet(true),
+              // }}
+              renderInput={({ field }) => (
+                <>
+                  {remainderData ? (
+                    <Alert
+                      type="info"
+                      message={`${remainderData.name}님에게 남은 ${remainderData.remainder}원이 부과됐어요.`}
+                    />
+                  ) : null}
+                  <MemberExpenses
+                    members={field.value}
+                    onDelete={(name) => {
+                      const newMembers = field.value.filter(
+                        (member: ExpenseFormMember) => member.name !== name
+                      );
+                      field.onChange(newMembers);
+                    }}
+                  />
+                </>
+              )}
+            />
+          </S.FormContainer>
+        </S.FormCard>
+        {/* // <MemberBottomSheet
       //   open={openMemberSheet}
       //   setOpen={setOpenMemberSheet}
       //   setGroupInfo={setGroupInfo}
-      // />
-      // </>
+      // /> */}
+      </>
     );
   }
 );

--- a/src/pages/createBill/components/MemberExpenses/index.styles.ts
+++ b/src/pages/createBill/components/MemberExpenses/index.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import Text from '@/common/components/Text';
 
 export const MemberExpensesContainer = styled.div`
   display: flex;
@@ -10,7 +11,11 @@ export const MemberExpensesContainer = styled.div`
 export const MemberContainer = styled.div`
   display: flex;
   align-items: center;
-  gap: ${({ theme }) => theme.unit[64]};
+  gap: clamp(
+    ${({ theme }) => theme.unit[24]},
+    10vw,
+    ${({ theme }) => theme.unit[64]}
+  );
   align-self: stretch;
 `;
 
@@ -21,6 +26,7 @@ export const ProfileContainer = styled.div`
   flex-direction: column;
   align-items: center;
   gap: ${({ theme }) => theme.unit[4]};
+  flex-shrink: 0;
 `;
 
 export const ProfileImg = styled.img`
@@ -41,4 +47,9 @@ export const DeleteButtonWrapper = styled.div`
   position: absolute; // 자식 요소
   width: fit-content;
   height: fit-content;
+`;
+
+/* 이름 */
+export const NameText = styled(Text)`
+  white-space: nowrap;
 `;

--- a/src/pages/createBill/components/MemberExpenses/index.tsx
+++ b/src/pages/createBill/components/MemberExpenses/index.tsx
@@ -1,6 +1,5 @@
 import { SystemDanger } from '@/assets/svgs/icon';
 import NumberInput from '@/common/components/NumberInput';
-import Text from '@/common/components/Text';
 import { ExpenseFormMember } from '@/pages/createBill/types/expense.type';
 import * as S from './index.styles';
 
@@ -26,7 +25,7 @@ function MemberExpenses({ members, onDelete }: MemberExpensesProps) {
                 </S.DeleteButtonWrapper>
               ) : null}
             </S.ProfileWrapper>
-            <Text variant="caption">{member.name}</Text>
+            <S.NameText variant="caption">{member.name}</S.NameText>
           </S.ProfileContainer>
           <NumberInput
             value={member.amount ? member.amount.toLocaleString() : ''}

--- a/src/pages/createBill/confirmStep/components/ExpenseCardList/index.styles.ts
+++ b/src/pages/createBill/confirmStep/components/ExpenseCardList/index.styles.ts
@@ -5,7 +5,7 @@ export const ListContainer = styled.div`
   flex-direction: column;
   gap: 1rem;
   width: 100%;
-  padding: 0rem 1.25rem;
+  padding: 0rem 1.25rem 1.25rem 1.25rem;
   flex: 1;
   overflow-y: auto;
   background-color: ${({ theme }) =>

--- a/src/pages/createBill/createExpenseStep/index.styles.ts
+++ b/src/pages/createBill/createExpenseStep/index.styles.ts
@@ -7,7 +7,8 @@ export const BillFormList = styled.form`
   width: 100%;
   flex: 1 0 0;
   overflow-y: auto;
-  padding: ${({ theme }) => `${theme.unit[24]} ${theme.unit[20]}`};
+  padding: ${({ theme }) =>
+    `0 ${theme.unit[20]} ${theme.unit[24]} ${theme.unit[20]}`};
   background: ${({ theme }) =>
     theme.color.semantic.background.normal.alternative};
 `;

--- a/src/pages/createBill/editExpenseStep/index.styles.ts
+++ b/src/pages/createBill/editExpenseStep/index.styles.ts
@@ -7,7 +7,8 @@ export const BillFormList = styled.form`
   width: 100%;
   flex: 1 0 0;
   overflow-y: auto;
-  padding: ${({ theme }) => `${theme.unit[24]} ${theme.unit[20]}`};
+  padding: ${({ theme }) =>
+    `0 ${theme.unit[20]} ${theme.unit[24]} ${theme.unit[20]}`};
   background: ${({ theme }) =>
     theme.color.semantic.background.normal.alternative};
 `;


### PR DESCRIPTION
## 📝 관련 이슈

- close #108

## 💻 작업 내용

문정님이 올려주신 노션의 UI QA 사항을 반영했습니다!! (내심 신경쓰였던 부분이라 후딱 작업했어용...)

### 1. 참여자 입력 창에서 input 버튼이 밀려나가던 문제

input의 늘어남 정도를 부모 컴포넌트에 맞추도록 min-width: 0 속성을 넣어주었습니다!
(추가로 지출 입력창에서 보니 너비가 좁아졌을 때 아이콘 사라지는 문제도 있어서, 아이콘은 줄어들지 않도록 해줬어요)

### 2. 지출 입력창에서 프로필이 작아지는 문제

프로필과 금액 사이의 기본 gap이 너무 넓었어서 발생한 문제라 clamp를 이용해서 반응형으로 gap을 조절하도록 했습니다!
추가로 프로필과 글자 모두 줄어들지 않도록 해줬어요

### 3. 스크롤이 여백 없이 올라가던 문제

카드를 기준으로 스크롤하던 것을 상단에 더미 컴포넌트를 두고 그쪽을 타겟으로 삼도록 했습니다...! (좋은 방법인진,, 모르겠어요..ㅎㅎㅜ)

## 📸 스크린샷

|AS-IS|TO-BE|
|---|---|
| <video src="https://github.com/user-attachments/assets/3abf0d96-28d9-4b30-ba14-8405bc1f435e" />  | <video src="https://github.com/user-attachments/assets/41271dbc-429b-40ee-8307-3691d3cdc0ca" /> |

|AS-IS|TO-BE|
|---|---|
|  <video src="https://github.com/user-attachments/assets/324dbcb3-dd1f-4807-92af-19aa9240df66" /> | <video src="https://github.com/user-attachments/assets/0c96e2ac-02fa-433d-833f-aa743113e685" /> |
