### PR TITLE
QA 2차 반영(특정 상황에서 groupSetup 상태 초기화, 모달 창 배경색 설정, HomeExpenseItem 컴포넌트 추가)

### DIFF
--- a/src/common/components/DefaultProgressBar/index.style.ts
+++ b/src/common/components/DefaultProgressBar/index.style.ts
@@ -4,10 +4,12 @@ export const Trail = styled.div`
   width: 100%;
   height: ${({ theme }) => theme.unit[8]};
   background: ${({ theme }) => theme.color.semantic.background.normal.default};
+  border-radius: ${({ theme }) => theme.radius.circle};
 `;
 
 export const Path = styled.div<{ percentage: number }>`
   width: ${({ percentage }) => `${percentage}%`};
   height: 100%;
   background: ${({ theme }) => theme.color.semantic.orange.default};
+  border-radius: ${({ theme }) => theme.radius.circle};
 `;

--- a/src/common/components/Modal/index.style.ts
+++ b/src/common/components/Modal/index.style.ts
@@ -28,6 +28,7 @@ export const ModalWrapper = styled.div`
   height: fit-content;
   max-width: 31rem;
   min-width: 16.563rem;
+  background: ${({ theme }) => theme.color.semantic.background.normal.default};
 `;
 
 export const DefaultWrapper = styled.div`
@@ -38,6 +39,7 @@ export const DefaultWrapper = styled.div`
   align-items: flex-start;
   height: 100%;
   width: 100%;
+  background: ${({ theme }) => theme.color.semantic.background.normal.default};
 `;
 
 export const TextWrapper = styled.div`

--- a/src/pages/billDetail/index.tsx
+++ b/src/pages/billDetail/index.tsx
@@ -19,6 +19,7 @@ import ExpenseTimeHeader from './components/ExpenseTimeHeader';
 import ExpenseMembers from './components/ExpenseMembers';
 import { StatusType } from './components/ExpenseTimeHeader/index.type';
 import ShareButton from '../createBill/shareStep/components/ShareButton';
+import { useGroupSetupStore } from '../groupSetup/stores/useGroupSetupStore';
 
 function BillDetail() {
   const { unit } = useTheme();
@@ -30,6 +31,7 @@ function BillDetail() {
   const { data: memberExpenseDetails } = useGetMemberExpenseDetails(groupToken);
   const [isChecked, setIsChecked] = useState<boolean>(false);
   const navigate = useNavigate();
+  const { clearGroupSetup } = useGroupSetupStore();
 
   let MEMBER_TOTAL = 0;
   let MEMBER_DONE = 0;
@@ -40,6 +42,12 @@ function BillDetail() {
   }
 
   const shareLink = generateShareLink(groupToken);
+
+  const handleBackToHome = () => {
+    localStorage.removeItem('groupToken');
+    clearGroupSetup();
+    navigate(ROUTE.home);
+  };
 
   return (
     <>
@@ -89,7 +97,7 @@ function BillDetail() {
         {MEMBER_TOTAL === MEMBER_DONE && status === 'pending' ? (
           <Button onClick={() => setIsChecked(false)}>정산 완료하기</Button>
         ) : status === 'success' ? (
-          <Button onClick={() => navigate(ROUTE.home)}>홈으로 돌아가기</Button>
+          <Button onClick={handleBackToHome}>홈으로 돌아가기</Button>
         ) : (
           <ShareButton shareLink={shareLink} />
         )}

--- a/src/pages/createBill/createExpenseStep/index.tsx
+++ b/src/pages/createBill/createExpenseStep/index.tsx
@@ -15,8 +15,8 @@ import getTotalExpense from '@/pages/createBill/utils/getTotalExpense';
 import { BillContext } from '@/pages/createBill/types/billContext.type';
 import Modal from '@/common/components/Modal';
 import { BottomButtonContainer } from '@/styles/bottomButton.styles';
-import * as S from './index.styles';
 import { useGroupSetupStore } from '@/pages/groupSetup/stores/useGroupSetupStore';
+import * as S from './index.styles';
 
 interface CreateExpenseStepProps
   extends BaseFunnelStepComponentProps<BillContext> {}
@@ -29,7 +29,7 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
   const navigate = useNavigate();
   const { groupInfo, formMethods, defaultFormValue, fieldArrayReturns } =
     useAddExpenseFormArray();
-  
+
   const { clearGroupSetup } = useGroupSetupStore();
 
   useLayoutEffect(() => {

--- a/src/pages/createBill/createExpenseStep/index.tsx
+++ b/src/pages/createBill/createExpenseStep/index.tsx
@@ -16,6 +16,7 @@ import { BillContext } from '@/pages/createBill/types/billContext.type';
 import Modal from '@/common/components/Modal';
 import { BottomButtonContainer } from '@/styles/bottomButton.styles';
 import * as S from './index.styles';
+import { useGroupSetupStore } from '@/pages/groupSetup/stores/useGroupSetupStore';
 
 interface CreateExpenseStepProps
   extends BaseFunnelStepComponentProps<BillContext> {}
@@ -28,6 +29,8 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
   const navigate = useNavigate();
   const { groupInfo, formMethods, defaultFormValue, fieldArrayReturns } =
     useAddExpenseFormArray();
+  
+  const { clearGroupSetup } = useGroupSetupStore();
 
   useLayoutEffect(() => {
     // form의 개수가 변경되면 (추가, 삭제) 마지막 form으로 스크롤 이동
@@ -47,6 +50,14 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
   };
   const handleDeleteExpense = (index: number) => {
     fieldArrayReturns.remove(index);
+  };
+
+  /** submit 버튼 클릭 시 기존 모임 생성 정보를 메모리에서 삭제하는 함수 */
+  const handleModalSubmit = () => {
+    localStorage.removeItem('groupToken');
+    clearGroupSetup();
+    setOpen(false);
+    navigate(ROUTE.home);
   };
 
   if (!groupInfo) {
@@ -72,10 +83,7 @@ function CreateExpenseStep({ moveToNextStep }: CreateExpenseStepProps) {
           cancel="계속 입력"
           submit="끝내기"
           onCancel={() => setOpen(false)}
-          onSubmit={() => {
-            setOpen(false);
-            navigate(ROUTE.home);
-          }}
+          onSubmit={handleModalSubmit}
         />
       )}
       <DescriptionField

--- a/src/pages/groupSetup/stores/useGroupSetupStore.ts
+++ b/src/pages/groupSetup/stores/useGroupSetupStore.ts
@@ -5,6 +5,7 @@ interface GroupSetupState {
   password: string;
   setGroupName: (groupName: string) => void;
   setPassword: (password: string) => void;
+  clearGroupSetup: () => void;
 }
 
 export const useGroupSetupStore = create<GroupSetupState>((set) => ({
@@ -12,4 +13,5 @@ export const useGroupSetupStore = create<GroupSetupState>((set) => ({
   password: '',
   setGroupName: (groupName) => set({ groupName }),
   setPassword: (password) => set({ password }),
+  clearGroupSetup: () => set({ groupName: '', password: '' }),
 }));

--- a/src/pages/home/components/HomeExpenseItem/index.style.ts
+++ b/src/pages/home/components/HomeExpenseItem/index.style.ts
@@ -1,0 +1,43 @@
+import { TextVariant } from '@/common/components/Text/index.styles';
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  width: 100%;
+  padding: ${({ theme }) => `0 ${theme.unit[20]}`};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.unit[10]};
+`;
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.unit[14]};
+  padding: ${({ theme }) => `${theme.unit[18]} ${theme.unit[20]}`};
+  background: ${({ theme }) => theme.color.semantic.background.normal.alternative};
+  border-radius: ${({ theme }) => theme.radius.default};
+  width: 100%;
+  height: fit-content;
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ProgressBarWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.unit[8]};
+  align-items: flex-end;
+  width: 100%;
+`;  
+
+export const ExpenseProgress = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.color.semantic.text.subtle};
+  font-weight: ${TextVariant('body1Sb')};
+  font-size: ${({ theme }) => theme.unit[14]};
+`;

--- a/src/pages/home/components/HomeExpenseItem/index.style.ts
+++ b/src/pages/home/components/HomeExpenseItem/index.style.ts
@@ -14,7 +14,8 @@ export const Container = styled.div`
   flex-direction: column;
   gap: ${({ theme }) => theme.unit[14]};
   padding: ${({ theme }) => `${theme.unit[18]} ${theme.unit[20]}`};
-  background: ${({ theme }) => theme.color.semantic.background.normal.alternative};
+  background: ${({ theme }) =>
+    theme.color.semantic.background.normal.alternative};
   border-radius: ${({ theme }) => theme.radius.default};
   width: 100%;
   height: fit-content;
@@ -31,7 +32,7 @@ export const ProgressBarWrapper = styled.div`
   gap: ${({ theme }) => theme.unit[8]};
   align-items: flex-end;
   width: 100%;
-`;  
+`;
 
 export const ExpenseProgress = styled.div`
   display: flex;

--- a/src/pages/home/components/HomeExpenseItem/index.tsx
+++ b/src/pages/home/components/HomeExpenseItem/index.tsx
@@ -1,9 +1,8 @@
-import { ExpenseChip } from '@/pages/billDetail/components/ExpenseTimeHeader/index.style';
-import * as S from './index.style';
 import { DollarCircle } from '@/assets/svgs/icon';
 import { useTheme } from 'styled-components';
 import Text from '@/common/components/Text';
 import DefaultProgressBar from '@/common/components/DefaultProgressBar';
+import * as S from './index.style';
 
 interface HomeExpenseItemProps {
   date: string;
@@ -52,7 +51,9 @@ function HomeExpenseItem({
                 fontSize: `${theme.unit[14]}`,
               }}
             >
-              <p style={{ color: `${theme.color.semantic.orange.default}` }}>{paidMember}</p>
+              <p style={{ color: `${theme.color.semantic.orange.default}` }}>
+                {paidMember}
+              </p>
               {`/${totalMember} 정산 완료`}
             </div>
           </S.ExpenseProgress>

--- a/src/pages/home/components/HomeExpenseItem/index.tsx
+++ b/src/pages/home/components/HomeExpenseItem/index.tsx
@@ -1,0 +1,65 @@
+import { ExpenseChip } from '@/pages/billDetail/components/ExpenseTimeHeader/index.style';
+import * as S from './index.style';
+import { DollarCircle } from '@/assets/svgs/icon';
+import { useTheme } from 'styled-components';
+import Text from '@/common/components/Text';
+import DefaultProgressBar from '@/common/components/DefaultProgressBar';
+
+interface HomeExpenseItemProps {
+  date: string;
+  groupName: string;
+  totalAmount: number;
+  paidMember: number;
+  totalMember: number;
+}
+
+function HomeExpenseItem({
+  date,
+  groupName,
+  totalAmount,
+  paidMember,
+  totalMember,
+}: HomeExpenseItemProps) {
+  const theme = useTheme();
+  const percentage = (paidMember / totalMember) * 100;
+
+  return (
+    <S.Wrapper>
+      <Text variant="body1Sb" color="semantic.text.default">
+        {date}
+      </Text>
+      <S.Container>
+        <S.TextWrapper>
+          <Text variant="body1R" color="semantic.text.default">
+            {groupName}
+          </Text>
+          <Text variant="heading2" color="semantic.text.default">
+            {totalAmount.toLocaleString()}원
+          </Text>
+        </S.TextWrapper>
+        <S.ProgressBarWrapper>
+          <DefaultProgressBar percentage={percentage} />
+          <S.ExpenseProgress>
+            <DollarCircle
+              width={`${theme.unit[28]}`}
+              style={{ paddingRight: `${theme.unit[4]}` }}
+            />
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'flex-end',
+                justifyContent: 'flex-end',
+                fontSize: `${theme.unit[14]}`,
+              }}
+            >
+              <p style={{ color: `${theme.color.semantic.orange.default}` }}>{paidMember}</p>
+              {`/${totalMember} 정산 완료`}
+            </div>
+          </S.ExpenseProgress>
+        </S.ProgressBarWrapper>
+      </S.Container>
+    </S.Wrapper>
+  );
+}
+
+export default HomeExpenseItem;

--- a/src/pages/home/index.style.ts
+++ b/src/pages/home/index.style.ts
@@ -111,3 +111,12 @@ export const BoxButtonWrapper = styled.div`
     `0 ${theme.unit[20]} ${theme.unit[32]} ${theme.unit[20]}`};
   gap: ${({ theme }) => theme.unit[8]};
 `;
+
+export const SettlementListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.unit[20]};
+  margin: ${({ theme }) => `${theme.unit[20]} 0`};
+  overflow-y: auto;
+  flex: 1;
+`;

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -67,6 +67,7 @@ function Home() {
           width={98}
           height={36}
           fill={theme.color.semantic.orange.default}
+          onClick={() => navigate(ROUTE.login)}
         />
         <Flex gap={4}>
           <Bell width={24} height={24} />

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -12,6 +12,39 @@ import CoinImg from '@/assets/pngs/CoinImg.png';
 import LinkMain from '@/assets/pngs/link_main.png';
 import CardMain from '@/assets/pngs/card_main.png';
 import * as S from './index.style';
+import HomeExpenseItem from './components/HomeExpenseItem';
+import Divider from '@/common/components/Divider';
+
+interface HomeExpenseItem {
+  date: string;
+  groupName: string;
+  totalAmount: number;
+  paidMember: number;
+  totalMember: number;
+  id: number;
+}
+/**
+ * @Todo 진행중인 정산 내역 조회 API 함수 호출
+ * 우선 mock data로 대체
+ * */
+const settlementList: HomeExpenseItem[] = [
+  {
+    id: 1,
+    date: '2025년 2월 22일',
+    groupName: 'DND 데모데이',
+    totalAmount: 120000,
+    paidMember: 3,
+    totalMember: 6,
+  },
+  {
+    id: 2,
+    date: '2025년 1월 14일',
+    groupName: 'DND 7조 첫모임',
+    totalAmount: 150000,
+    paidMember: 5,
+    totalMember: 6,
+  },
+];
 
 function Home() {
   const [settlementType, setSettlementType] = useState<'RECEIVE' | 'SEND'>(
@@ -27,11 +60,8 @@ function Home() {
     setSettlementType(type);
   };
 
-  /** @Todo 진행중인 정산 내역 조회 API 함수 호출 */
-  const settlementList = [];
-
   return (
-    <Flex direction="column" height="100dvh">
+    <Flex direction="column" flexGrow={1}>
       <S.MainHeader>
         <LogoIcon
           width={98}
@@ -84,7 +114,7 @@ function Home() {
           <S.SmallImg src={CardMain} />
         </S.BoxButton>
       </S.BoxButtonWrapper>
-      <S.Hr />
+      <Divider />
       <Flex direction="column" gap={2} pt={5} flexGrow={1}>
         <S.SettlementTitle>진행중인 정산</S.SettlementTitle>
         <Flex justifyContent="space-between" px={5} py={3} alignItems="center">
@@ -107,10 +137,21 @@ function Home() {
             <Next width={theme.unit[24]} height={theme.unit[24]} />
           </Flex>
         </Flex>
-        {settlementList.length > 0 ? (
-          /** @Todo 정산리스트 컴포넌트 구현 */
-          <div>정산리스트</div>
-        ) : (
+        {settlementList.length > 0 && settlementType === 'RECEIVE' && (
+          <S.SettlementListWrapper>
+            {settlementList.map((data) => (
+              <HomeExpenseItem
+                key={data.id}
+                date={data.date}
+                groupName={data.groupName}
+                totalAmount={data.totalAmount}
+                paidMember={data.paidMember}
+                totalMember={data.totalMember}
+              />
+            ))}
+          </S.SettlementListWrapper>
+        )}
+        {settlementType === 'SEND' && (
           <Flex
             direction="column"
             py={15}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -11,11 +11,11 @@ import { useState } from 'react';
 import CoinImg from '@/assets/pngs/CoinImg.png';
 import LinkMain from '@/assets/pngs/link_main.png';
 import CardMain from '@/assets/pngs/card_main.png';
+import Divider from '@/common/components/Divider';
 import * as S from './index.style';
 import HomeExpenseItem from './components/HomeExpenseItem';
-import Divider from '@/common/components/Divider';
 
-interface HomeExpenseItem {
+interface HomeExpenseItemType {
   date: string;
   groupName: string;
   totalAmount: number;
@@ -27,7 +27,7 @@ interface HomeExpenseItem {
  * @Todo 진행중인 정산 내역 조회 API 함수 호출
  * 우선 mock data로 대체
  * */
-const settlementList: HomeExpenseItem[] = [
+const settlementList: HomeExpenseItemType[] = [
   {
     id: 1,
     date: '2025년 2월 22일',

--- a/src/pages/selectGroup/index.tsx
+++ b/src/pages/selectGroup/index.tsx
@@ -39,7 +39,6 @@ function SelectGroup() {
         justify="space-between"
         height="100%"
         pt="10px"
-        mb="32px"
         flexGrow={1}
         bgColor="#f1f3f5"
       >


### PR DESCRIPTION
## 📝 관련 이슈

- close #112 

## 💻 작업 내용

- 특정 상황에서 그룹 생성 데이터를 메모리에서 초기화하는 함수를 store에 추가하고 실행되도록 구현했습니다. 다음과 같은 상황에서 그룹 생성 데이터와 그룹 토큰 삭제 후 홈페이지로 이동합니다.
  - 지출 생성 페이지에서 상단 좌측의 X 버튼을 클릭하여 나오는 모달에서 "확인" 버튼을 누를 시
  - 정산 진행 페이지에서 정산 완료 후 홈페이지로 돌아가기 버튼 클릭 시 
 
- 모달 창의 배경색이 설정되지 않아 모바일 화면에서 일부분이 투명하게 나오는 문제를 해결했습니다.

- 홈페이지에서 진행중인 정산을 나타내는 HomeExpenseItem UI 컴포넌트를 구현했습니다.
  - 현재 관련된 api가 없어 mockData를 임의로 넣어두었습니다.
  - 진행중인 정산이 없는 케이스도 보여주기 위해 보낼 정산 탭에 임의로 해당 컴포넌트를 나타나게 했습니다.

- 홈페이지에서 좌측 로고 클릭 시 로그인 페이지로 이동하는 로직을 추가했습니다.
  - 이건 제가 테스트를 위해 자의적으로 추가한거라... 애매하면 빼겠습니당

## 📸 스크린샷

<img src="https://github.com/user-attachments/assets/5bc1a8aa-c430-4a99-8063-cf7cce05b3f0" width="300">
<img src="https://github.com/user-attachments/assets/96c35fc4-4c8c-48f8-aad1-40763fc9f468" width="300">

## 👻 리뷰 요구사항 (선택)

<!--구현하면서 고민했던 부분이 있다면 알려주세요.-->
