### PR TITLE
경로를 케밥 케이스 표기로 통일

### DIFF
--- a/src/common/constants/route.ts
+++ b/src/common/constants/route.ts
@@ -6,8 +6,8 @@ export const ROUTE = {
   onboarding: '/onboarding',
   home: '/home',
   createBill: '/create-bill',
-  selectGroup: '/selectGroup',
-  groupSetup: '/groupSetup',
+  selectGroup: '/select-group',
+  groupSetup: '/group-setup',
   billDetail: '/bill-detail/:groupToken',
   billDetailCharacterShare: '/bill-detail/:groupToken/character',
 } as const;


### PR DESCRIPTION
## 📝 관련 이슈

[MOD-56](https://moddo-kr.atlassian.net/browse/MOD-56)

## 💻 작업 내용

케밥 케이스와 카멜 케이스 표기가 섞여 있던 경로들을 모두 케밥 케이스로 통일했습니다.

[Google의 URL 구조 권장사항](https://developers.google.com/search/docs/crawling-indexing/url-structure?hl=ko)를 참고해서 케밥 케이스로 결정했어요.

> 하이픈을 사용하여 URL 내의 단어를 분리해 보세요. 사용자와 검색엔진이 URL의 개념을 더 쉽게 식별할 수 있습니다. URL에 밑줄(_) 대신 하이픈(-)을 사용하는 것이 좋습니다.

## 👻 참고(?)

원래 이 PR에 ROUTE 내부 프로퍼티 이름들을 대문자로 변경하려고 했었는데요 ㅎㅎ..
에어비앤비 스타일 가이드에 보니 프로퍼티 이름들까지 대문자로 변경하는 것은 불필요하다고 정리되어 있더라고요...!!
이미 알고 계셨을수도 있지만,,, 저는 처음 아는 사실이라 같이 링크해봅니다..ㅎㅎ

https://airbnb.io/javascript/#naming--uppercase

[MOD-56]: https://moddo-kr.atlassian.net/browse/MOD-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ